### PR TITLE
Use steal requests as pointers

### DIFF
--- a/weave/datatypes/context_thread_local.nim
+++ b/weave/datatypes/context_thread_local.nim
@@ -8,7 +8,7 @@
 import
   ./bounded_queues, ./sync_types, ./prell_deques,
   ../config,
-  ../memory/intrusive_stacks,
+  ../memory/[intrusive_stacks, persistacks, allocs],
   ../instrumentation/contracts,
   system/ansi_c
 
@@ -72,6 +72,7 @@ type
     worker*: Worker
     thefts*: Thefts
     taskCache*: IntrusiveStack[Task]
+    stealCache*: Persistack[WV_MaxConcurrentStealPerWorker, deref(StealRequest)]
     # Leader thread only - Whole runtime is quiescent
     runtimeIsQuiescent*: bool
     when defined(WV_Metrics):

--- a/weave/datatypes/sync_types.nim
+++ b/weave/datatypes/sync_types.nim
@@ -71,7 +71,7 @@ type
 
   # Padding shouldn't be needed as steal requests are used as value types
   # and deep-copied between threads
-  StealRequest* = object
+  StealRequest* = ptr object
     thiefAddr*: ptr ChannelSpscSinglePtr[Task]       # Channel for sending tasks back to the thief
     thiefID*: WorkerID
     retry*: int32                                 # 0 <= retry <= num_workers

--- a/weave/memory/persistacks.nim
+++ b/weave/memory/persistacks.nim
@@ -8,7 +8,8 @@
 import
   std/typetraits,
   ../config,
-  ../instrumentation/contracts
+  ../instrumentation/contracts,
+  ../memory/allocs
 
 type
   Persistack*[N: static int8, T: object] = object
@@ -68,7 +69,7 @@ proc initialize*[N: static int8, T](ps: var Persistack[N, T]) =
   ##
   ## Important: The objects themselves are created uninitialized.
   ##            Make sure you properly initialize them before use.
-  ps.rawMem = cast[ptr array[N, T]](createU(T, N))
+  ps.rawMem = cast[ptr array[N, T]](wv_alloc(T, N))
   for i in 0 ..< N:
     ps.stack[i] = ps.rawMem[i].addr
   ps.len = N

--- a/weave/scheduler.nim
+++ b/weave/scheduler.nim
@@ -29,6 +29,7 @@ proc init*(ctx: var TLContext) =
   myWorker().deque = newPrellDeque(Task)
   myThieves().initialize(WV_MaxConcurrentStealPerWorker * workforce())
   myTodoBoxes().initialize()
+  localCtx.stealCache.initialize()
   myWorker().initialize(maxID = workforce() - 1)
 
   ascertain: myTodoBoxes().len == WV_MaxConcurrentStealPerWorker

--- a/weave/workers.nim
+++ b/weave/workers.nim
@@ -43,6 +43,7 @@ proc recv*(task: var Task, isOutOfTasks: bool): bool =
                             .tryRecv(task)
       if result:
         myTodoBoxes().nowAvailable(i)
+        localCtx.stealCache.nowAvailable(i)
         debug: log("Worker %d received a task with function address %d\n", myID(), task.fn)
         break
 


### PR DESCRIPTION
20% speed increase on LazyFlowvar and 5% speed increase on eager flowvar

Seems like it's a keep. (closes #7)

Lazy with ptr Steal request on fib(40) with 36 threads
```
real    0m0.179s
user    0m6.018s
sys     0m0.020s
```

Lazy without
```
real    0m0.230s
user    0m7.846s
sys     0m0.010s
```
-----------------------------------------------------------------------

Eager with

```
real    0m0.434s
user    0m15.143s
sys     0m0.017s
```

Eager without

```
real    0m0.483s
user    0m16.789s
sys     0m0.020s
```

-----------------------------------------------------------------

The original port as the same perf as the C code and serves as a reference perf.
The LazyFutures was a bit slower and the Eager future was a bit faster

Lazy
```
real    0m0.299s
user    0m10.253s
sys     0m0.014s
```

Eager
```
real    0m0.459s
user    0m15.922s
sys     0m0.017s
```

-----------------------------------------------------------------

Competition

clang -O3 -fopenmp -march=native benchmarks/fibonacci/omp_fib.c
```
real    0m2.122s
user    0m52.494s
sys     0m23.173s
```

g++ -O3 -ltbb -march=native benchmarks/fibonacci/tbb_class_fib.cpp
```
real    0m0.609s
user    0m21.083s
sys     0m0.010s
```
g++ -O3 -ltbb -march=native benchmarks/fibonacci/tbb_closure_fib.cpp
```
real    0m0.928s
user    0m33.096s
sys     0m0.017s
```

------------------------------------------------------------------

After the rewrite we are approaching 2x less overhead than the original code and almost 4x less overheads than Intel TBB.

This also reduces the space taken in the MPSC channel and opens up further optimizations on the victims bitset #5 and lock free MPSC channel #6