### PR TITLE
Use more robust RNG

### DIFF
--- a/weave/datatypes/context_thread_local.nim
+++ b/weave/datatypes/context_thread_local.nim
@@ -10,7 +10,7 @@ import
   ../config,
   ../memory/[intrusive_stacks, persistacks, allocs],
   ../instrumentation/contracts,
-  system/ansi_c
+  ../random/rng
 
 # Thread-local context
 # ----------------------------------------------------------------------------------
@@ -57,7 +57,7 @@ type
     # steal request and send the remaining one to its parent
     dropped*: int32
     # RRNG state to choose victims
-    rng*: uint32
+    rng*: RngState
     when defined(StealLastVictim):
       lastVictim*: WorkerID
     when defined(StealLastThief):

--- a/weave/datatypes/sparsesets.nim
+++ b/weave/datatypes/sparsesets.nim
@@ -9,7 +9,7 @@ import
   ../config,
   ../instrumentation/contracts,
   ../memory/allocs,
-  ../primitives/c
+  ../random/rng
 
 template selectUint(): typedesc =
   # we keep high(uint) i;e. 0xFFFFFFFF ...
@@ -117,12 +117,12 @@ func excl*(s: var SparseSet, n: SomeInteger) {.inline.} =
   # Erase the item
   s.indices[n] = Empty
 
-func randomPick*(s: SparseSet, rngState: var uint32): int32 =
+func randomPick*(s: SparseSet, rng: var RngState): int32 =
   ## Randomly pick from the set.
   # The value is NOT removed from it.
   # TODO: this would require rejection sampling for proper uniform distribution
   # TODO: use a rng with better speed / distribution
-  let pickIdx = rand_r(rngState) mod s.len.int32
+  let pickIdx = rng.uniform(s.len)
   result = s.values[pickIdx].int32
 
 func `$`*(s: SparseSet): string =

--- a/weave/memory/object_pools.nim
+++ b/weave/memory/object_pools.nim
@@ -5,10 +5,5 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-# Random
-# ----------------------------------------------------------------------------------
-
-proc rand_r*(seed: var uint32): int32 {.header: "<stdlib.h>".}
-  ## Random number generator from C stdlib
-  ## small amount of state
-  ## TODO: replace by Nim's
+# Threadsafe object pool
+# ------------------------------------------------------------------------------

--- a/weave/random/rng.nim
+++ b/weave/random/rng.nim
@@ -1,0 +1,72 @@
+# Weave
+# Copyright (c) 2019 Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import ../instrumentation/contracts
+
+# Random Number Generator
+# ----------------------------------------------------------------------------------
+
+# The RNG will be used for victim selection
+# Unfortunately xoroshiro128+ (Nim default) low bits fails linearity tests
+# We need to use the high bits instead which Nim random doesn't allow us to do.
+# We might aswell use xoshiro256++ which is almost as fast but doesn't fail
+# Hamming Weight dependency test after 5 TB of data
+# and has a period of 2^256-1 instead of 2^128.
+# Compared to xoshiro256+ (and xoroshiro128+) the low bits
+# don't have low linearity so we can directly take a modulo
+# instead of shifting to only retain the high bits and then modulo.
+#
+# http://prng.di.unimi.it/
+#
+# We initialize the RNG with SplitMix64
+
+type RngState* = object
+  s0, s1, s2, s3: uint64
+
+func splitMix64(state: var uint64): uint64 =
+  state += 0x9e3779b97f4a7c15'u64
+  result = state
+  result = (result xor (result shr 30)) * 0xbf58476d1ce4e5b9'u64
+  result = (result xor (result shr 27)) * 0xbf58476d1ce4e5b9'u64
+  result = result xor (result shr 31)
+
+func seed*(rng: var RngState, x: SomeInteger) =
+  ## Seed the random number generator with a fixed seed
+  var sm64 = uint64(x)
+  rng.s0 = splitMix64(sm64)
+  rng.s1 = splitMix64(sm64)
+  rng.s2 = splitMix64(sm64)
+  rng.s3 = splitMix64(sm64)
+
+func rotl(x: uint64, k: static int): uint64 {.inline.} =
+  return (x shl k) or (x shr (64 - k))
+
+func next(rng: var RngState): uint64 =
+  ## Compute a random uint64 from the input state
+  ## using xoshiro256++ algorithm by Vigna et al
+  ## State is updated.
+  result = rotl(rng.s0 + rng.s3, 23) + rng.s0
+
+  let t = rng.s1 shl 17
+  rng.s2 = rng.s2 xor rng.s0
+  rng.s3 = rng.s3 xor rng.s1
+  rng.s1 = rng.s1 xor rng.s2
+  rng.s0 = rng.s0 xor rng.s3
+
+  rng.s2 = rng.s2 xor t
+
+  rng.s3 = rotl(rng.s3, 45)
+
+func uniform*(rng: var RngState, max: SomeInteger): int32 =
+  ## Returns a random integer in the range 0 ..< max
+  ## Unlike Nim ``random`` stdlib, max is excluded.
+  preCondition: max > 0
+  while true:
+    let x = rng.next()
+    if x <= high(uint64) - (high(uint64) mod uint64(max)):
+      # We use rejection sampling to have a uniform distribution
+      return int32(x mod uint64(max))

--- a/weave/scheduler.nim
+++ b/weave/scheduler.nim
@@ -13,7 +13,8 @@ import
   ./memory/[persistacks, intrusive_stacks],
   ./contexts, ./config,
   ./victims, ./loop_splitting,
-  ./thieves, ./workers
+  ./thieves, ./workers,
+  ./random/rng
 
 
 # Public routines
@@ -38,7 +39,7 @@ proc init*(ctx: var TLContext) =
   ascertain: myTodoBoxes().len == WV_MaxConcurrentStealPerWorker
 
   # Workers see their RNG with their myID()
-  myThefts().rng = uint32 myID()
+  myThefts().rng.seed(myID())
 
   # Thread-Local Profiling
   profile_init(run_task)

--- a/weave/targets.nim
+++ b/weave/targets.nim
@@ -8,7 +8,7 @@
 import
   ./datatypes/[sparsesets, sync_types, context_thread_local],
   ./contexts,
-  ./primitives/c,
+  ./random/rng,
   ./instrumentation/[contracts, loggers],
   ./config,
   ./memory/allocs
@@ -60,9 +60,9 @@ proc findVictim*(req: var StealRequest): WorkerID =
     # Steal request initiated by the current worker.
     # Send it to a random one
     ascertain: req.retry == 0
-    result = rand_r(myThefts().rng) mod workforce()
+    result = myThefts().rng.uniform(workforce())
     while result == myID():
-      result = rand_r(myThefts().rng) mod workforce()
+      result = myThefts().rng.uniform(workforce())
   elif req.retry == WV_MaxRetriesPerSteal:
     # Return steal request to thief
     # logVictims(req.victims, req.thiefID)


### PR DESCRIPTION
This changes the RNG from the C stdlib which only has 32-bit of state to xoshiro256++ which is a robust general purpose RNG.

Compared to Nim default:
- It avoids the awkward -1, +1 for the inclusive ranges.
- The lower bits of xoroshiro128+ (and any + algo of that family) have low linearity, meaning taking a modulo with a low number is somewhat bad (but this is also true for Mersenne Twister and may others).
  The workaround is to use a ++ or a ** algorithm or only use the higher bits via shifting.
- It should be slightly slower but due to the large instruction level parallelism on xor it should take still below a nanosecond to generate a random number.

Measured no perf difference