### PR TITLE
Change to lockless unbounded mpsc

### DIFF
--- a/weave/async.nim
+++ b/weave/async.nim
@@ -148,7 +148,7 @@ when isMainModule:
       sync(Runtime)
       exit(Runtime)
 
-    # main()
+    main()
 
   block: # Async/Await
 
@@ -173,4 +173,4 @@ when isMainModule:
 
       echo f
 
-    main2()
+    # main2()

--- a/weave/async.nim
+++ b/weave/async.nim
@@ -148,7 +148,7 @@ when isMainModule:
       sync(Runtime)
       exit(Runtime)
 
-    main()
+    # main()
 
   block: # Async/Await
 
@@ -173,4 +173,4 @@ when isMainModule:
 
       echo f
 
-    # main2()
+    main2()

--- a/weave/contexts.nim
+++ b/weave/contexts.nim
@@ -7,7 +7,7 @@
 
 import
   ./datatypes/[context_global, context_thread_local, sync_types],
-  ./channels/[channels_spsc_single_ptr, channels_mpsc_bounded_lock],
+  ./channels/[channels_spsc_single_ptr, channels_mpsc_bounded_lock, channels_mpsc_unbounded],
   ./memory/[persistacks, intrusive_stacks],
   ./config,
   system/ansi_c,
@@ -65,7 +65,7 @@ proc initialize*[T](c: var ChannelLegacy[T], size: int32) =
 proc delete*[T](c: var ChannelLegacy[T]) =
   channel_free(c)
 
-template myThieves*: ChannelLegacy[StealRequest] =
+template myThieves*: ChannelMpscUnbounded[StealRequest] =
   globalCtx.com.thefts[localCtx.worker.ID]
 
 template workforce*: int32 =

--- a/weave/datatypes/context_global.nim
+++ b/weave/datatypes/context_global.nim
@@ -7,6 +7,7 @@
 
 import
   ../channels/channels_mpsc_bounded_lock,
+  ../channels/channels_mpsc_unbounded,
   ../channels/channels_spsc_single_ptr,
   ../memory/persistacks,
   ../config,
@@ -35,7 +36,7 @@ type
     #   would work but then it requires a pointer indirection
     #   per channel
     #   and a known max number of workers
-    thefts*: ptr UncheckedArray[ChannelLegacy[StealRequest]]
+    thefts*: ptr UncheckedArray[ChannelMPSCunbounded[StealRequest]]
     tasks*: ptr UncheckedArray[Persistack[WV_MaxConcurrentStealPerWorker, ChannelSpscSinglePtr[Task]]]
 
   GlobalContext* = object

--- a/weave/datatypes/sparsesets.nim
+++ b/weave/datatypes/sparsesets.nim
@@ -49,9 +49,6 @@ type
 
 func allocate*(s: var SparseSet, capacity: SomeInteger) =
   preCondition: capacity <= WV_MaxWorkers
-  preCondition: s.indices.isNil
-  preCondition: s.values.isNil
-  preCondition: s.rawBuffer.isNil
 
   s.capacity = Setuint capacity
   s.rawBuffer = wv_alloc(Setuint, 2*capacity)

--- a/weave/datatypes/sync_types.nim
+++ b/weave/datatypes/sync_types.nim
@@ -73,7 +73,9 @@ type
   # Padding shouldn't be needed as steal requests are used as value types
   # and deep-copied between threads
   StealRequest* = ptr object
-    next*: Atomic[StealRequest]                   # For intrusive lists and queues
+    # TODO: padding to cache line
+    # TODO: Remove workaround generic atomics bug: https://github.com/nim-lang/Nim/issues/12695
+    next*: Atomic[pointer]                        # For intrusive lists and queues
     thiefAddr*: ptr ChannelSpscSinglePtr[Task]    # Channel for sending tasks back to the thief
     thiefID*: WorkerID
     retry*: int32                                 # 0 <= retry <= num_workers

--- a/weave/datatypes/sync_types.nim
+++ b/weave/datatypes/sync_types.nim
@@ -10,7 +10,8 @@ import
   ../config,
   ../channels/channels_spsc_single_ptr,
   ../instrumentation/contracts,
-  ../memory/allocs
+  ../memory/allocs,
+  std/atomics
 
 # Inter-thread synchronization types
 # ----------------------------------------------------------------------------------
@@ -72,7 +73,8 @@ type
   # Padding shouldn't be needed as steal requests are used as value types
   # and deep-copied between threads
   StealRequest* = ptr object
-    thiefAddr*: ptr ChannelSpscSinglePtr[Task]       # Channel for sending tasks back to the thief
+    next*: Atomic[StealRequest]                   # For intrusive lists and queues
+    thiefAddr*: ptr ChannelSpscSinglePtr[Task]    # Channel for sending tasks back to the thief
     thiefID*: WorkerID
     retry*: int32                                 # 0 <= retry <= num_workers
     victims*: SparseSet                           # set of potential victims

--- a/weave/primitives/compiler_optimization_hints.nim
+++ b/weave/primitives/compiler_optimization_hints.nim
@@ -18,8 +18,8 @@ const withBuiltins = defined(gcc) or defined(clang) or defined(icc)
 when withBuiltins:
   proc builtin_prefetch(data: pointer, rw: PrefetchRW, locality: PrefetchLocality) {.importc: "__builtin_prefetch", noDecl.}
 
-template prefetch*[T](
-            data: ptr (T or UncheckedArray[T]),
+template prefetch*(
+            data: pointer,
             rw: static PrefetchRW = Read,
             locality: static PrefetchLocality = HighTemporalLocality) =
   ## Prefetch examples:

--- a/weave/runtime.nim
+++ b/weave/runtime.nim
@@ -12,7 +12,7 @@ import
   ./instrumentation/[contracts, profilers, loggers],
   ./contexts, ./config,
   ./datatypes/[sync_types, prell_deques],
-  ./channels/[channels_mpsc_bounded_lock, channels_spsc_single_ptr],
+  ./channels/[channels_mpsc_bounded_lock, channels_spsc_single_ptr, channels_mpsc_unbounded],
   ./memory/[persistacks, intrusive_stacks, allocs],
   ./scheduler, ./signals, ./workers, ./thieves, ./victims,
   # Low-level primitives
@@ -40,7 +40,7 @@ proc init*(_: type Runtime) =
 
   ## Allocation of the global context.
   globalCtx.threadpool = wv_alloc(Thread[WorkerID], workforce())
-  globalCtx.com.thefts = wv_alloc(ChannelLegacy[StealRequest], workforce())
+  globalCtx.com.thefts = wv_alloc(ChannelMpscUnbounded[StealRequest], workforce())
   globalCtx.com.tasks = wv_alloc(Persistack[WV_MaxConcurrentStealPerWorker, ChannelSpscSinglePtr[Task]], workforce())
   discard pthread_barrier_init(globalCtx.barrier, nil, workforce())
 

--- a/weave/scheduler.nim
+++ b/weave/scheduler.nim
@@ -30,10 +30,7 @@ proc init*(ctx: var TLContext) =
   myWorker().deque = newPrellDeque(Task)
   myTodoBoxes().initialize()
   myWorker().initialize(maxID = workforce() - 1)
-
-  # The StealRequest MPSC channel requires a dummy node
-  let dummy = wv_allocPtr(StealRequest)
-  myThieves().initialize(dummy)
+  myThieves().initialize()
 
   localCtx.stealCache.initialize()
   for i in 0 ..< localCtx.stealCache.len:
@@ -41,7 +38,7 @@ proc init*(ctx: var TLContext) =
 
   ascertain: myTodoBoxes().len == WV_MaxConcurrentStealPerWorker
 
-  # Workers see their RNG with their myID()
+  # Workers seed their RNG with their myID()
   myThefts().rng.seed(myID())
 
   # Thread-Local Profiling
@@ -151,8 +148,6 @@ proc schedulingLoop() =
 
 proc threadLocalCleanup*() =
   myWorker().deque.delete()
-  myThieves().removeDummy().wv_free()
-  # myThieves().delete()
 
   for i in 0 ..< WV_MaxConcurrentStealPerWorker:
     # No tasks left

--- a/weave/thieves.nim
+++ b/weave/thieves.nim
@@ -11,7 +11,8 @@ import
   ./instrumentation/[contracts, profilers, loggers],
   ./channels/channels_mpsc_unbounded,
   ./memory/persistacks,
-  ./config, ./signals
+  ./config, ./signals,
+  std/atomics
 
 # Thief
 # ----------------------------------------------------------------------------------
@@ -22,6 +23,7 @@ proc newStealRequest(): StealRequest {.inline.} =
   result = localCtx.stealCache.borrow()
   ascertain: result.victims.capacity.int32 == workforce()
 
+  result.next.store(nil, moRelaxed)
   result.thiefAddr = myTodoBoxes.borrow()
   result.thiefID = myID()
   result.retry = 0

--- a/weave/thieves.nim
+++ b/weave/thieves.nim
@@ -9,7 +9,7 @@ import
   ./datatypes/[sparsesets, sync_types, context_thread_local],
   ./contexts, ./targets,
   ./instrumentation/[contracts, profilers, loggers],
-  ./channels/channels_mpsc_bounded_lock,
+  ./channels/channels_mpsc_unbounded,
   ./memory/persistacks,
   ./config, ./signals
 

--- a/weave/thieves.nim
+++ b/weave/thieves.nim
@@ -38,6 +38,8 @@ proc newStealRequest(): StealRequest {.inline.} =
 proc rawSend(victimID: WorkerID, req: sink StealRequest) {.inline.}=
   ## Send a steal or work sharing request
   # TODO: check for race condition on runtime exit
+  # log("Worker %d: sending request 0x%.08x to %d (Channel: 0x%.08x)\n",
+  #       myID(), cast[ByteAddress](req), victimID, globalCtx.com.thefts[victimID].addr)
   let stealRequestSent = globalCtx.com
                                   .thefts[victimID]
                                   .trySend(req)

--- a/weave/victims.nim
+++ b/weave/victims.nim
@@ -10,7 +10,7 @@ import
                sparsesets, prell_deques, flowvars],
   ./contexts, ./config,
   ./instrumentation/[contracts, profilers, loggers],
-  ./channels/[channels_mpsc_bounded_lock, channels_spsc_single_ptr],
+  ./channels/[channels_mpsc_bounded_lock, channels_spsc_single_ptr, channels_mpsc_unbounded],
   ./thieves, ./loop_splitting
 
 # Victims - Adaptative task splitting

--- a/weave/victims.nim
+++ b/weave/victims.nim
@@ -38,6 +38,11 @@ proc recv*(req: var StealRequest): bool {.inline.} =
   profile(send_recv_req):
     result = myThieves().tryRecv(req)
 
+    debug:
+      if result:
+        log("Worker %d: receives request 0x%.08x from %d with %d potential victims. (Channel: 0x%.08x)\n",
+              myID(), cast[ByteAddress](req), req.thiefID, req.victims.len, myThieves().addr)
+
     # We treat specially the case where children fail to steal
     # and defer to the current worker (their parent)
     while result and req.state == Waiting:


### PR DESCRIPTION
Implemented lockless unbounded MPSC channels.

## Original issue

The initial implementation was based on snmalloc paper (itself inspired by Pony).
The idea was to use it for both:
- the future memory pool that needs a way to transfer onership of memory block back to the thread that allocated them in the first place
- steal request

However they have the following issues:
- they hold on the last item of a queue (breaking for steal requests)
- they require memory management of the dummy node (snmalloc deletes it and its memory doesn't seem to be reclaimed)
- they never touch the "back" pointer of the queue when dequeuing, meaning if an item was last, dequeuing will still points to it. Pony has an emptiness check via tagged pointer and snmalloc does something unknown.

## Overhead / Performance

On fib(40) with i9-9980XE (36 cores OC @ 4.1 GHz)

![DeepinScreenshot_select-area_20191123183003](https://user-images.githubusercontent.com/22738317/69482838-8321e380-0e20-11ea-8eaf-8e4ec90fabe2.png)

![DeepinScreenshot_select-area_20191123183051](https://user-images.githubusercontent.com/22738317/69482839-861cd400-0e20-11ea-8098-c8028327f37f.png)

We gain 10-20 ms (5-10%) and also avoids a thread blocking a steal request channel

----------------------------
## Investigation details

Full details from https://github.com/mratsim/weave/issues/19#issuecomment-557785843

> 
> It seems like there is an issue with snmalloc channels (adapted from Pony's) or I adapted them improperly.
> 
> snmalloc pseudo code from paper
> 
> ![DeepinScreenshot_select-area_20191123105253](https://user-images.githubusercontent.com/22738317/69476853-6fa25880-0ddf-11ea-9af9-c3f8a8f12719.png)
> 
> ![DeepinScreenshot_select-area_20191123105346](https://user-images.githubusercontent.com/22738317/69476864-8943a000-0ddf-11ea-9f43-e5f7c22197a5.png)
> 
> ![image](https://user-images.githubusercontent.com/22738317/69476940-636acb00-0de0-11ea-8a79-9b9751ea8daa.png)
> 
> Code from: https://github.com/microsoft/snmalloc/blob/7faefbbb0ed69554d0e19bfe901ec5b28e046a82/src/ds/mpscq.h#L29-L83
> 
> ```C++
>     void init(T* stub)
>     {
>       stub->next.store(nullptr, std::memory_order_relaxed);
>       front = stub;
>       back.store(stub, std::memory_order_relaxed);
>       invariant();
>     }
> 
>     T* destroy()
>     {
>       T* fnt = front;
>       back.store(nullptr, std::memory_order_relaxed);
>       front = nullptr;
>       return fnt;
>     }
> 
>     inline bool is_empty()
>     {
>       T* bk = back.load(std::memory_order_relaxed);
> 
>       return bk == front;
>     }
> 
>     void enqueue(T* first, T* last)
>     {
>       // Pushes a list of messages to the queue. Each message from first to
>       // last should be linked together through their next pointers.
>       invariant();
>       last->next.store(nullptr, std::memory_order_relaxed);
>       std::atomic_thread_fence(std::memory_order_release);
>       T* prev = back.exchange(last, std::memory_order_relaxed);
>       prev->next.store(first, std::memory_order_relaxed);
>     }
> 
>     std::pair<T*, bool> dequeue()
>     {
>       // Returns the front message, or null if not possible to return a message.
>       invariant();
>       T* first = front;
>       T* next = first->next.load(std::memory_order_relaxed);
> 
>       if (next != nullptr)
>       {
>         front = next;
>         AAL::prefetch(&(next->next));
>         assert(front);
>         std::atomic_thread_fence(std::memory_order_acquire);
>         invariant();
>         return std::pair(first, true);
>       }
> 
>       return std::pair(nullptr, false);
>     }
>   };
> } // namespace snmalloc
> ```
> 
> Pony: https://qconlondon.com/london-2016/system/files/presentation-slides/sylvanclebsch.pdf
> 
> ![DeepinScreenshot_select-area_20191123110607](https://user-images.githubusercontent.com/22738317/69477011-5c908800-0de1-11ea-8bcf-37870f8cf203.png)
> 
> ![DeepinScreenshot_select-area_20191123110621](https://user-images.githubusercontent.com/22738317/69477012-60240f00-0de1-11ea-957e-e639e8cae483.png)
> 
> Code from https://github.com/ponylang/ponyc/blob/7145c2a84b68ae5b307f0756eee67c222aa02fda/src/libponyrt/actor/messageq.c
> 
> Note that Pony enqueue at the head and dequeue at the tail
> 
> ```C
> static bool messageq_push(messageq_t* q, pony_msg_t* first, pony_msg_t* last)
> {
>   atomic_store_explicit(&last->next, NULL, memory_order_relaxed);
> 
>   // Without that fence, the store to last->next above could be reordered after
>   // the exchange on the head and after the store to prev->next done by the
>   // next push, which would result in the pop incorrectly seeing the queue as
>   // empty.
>   // Also synchronise with the pop on prev->next.
>   atomic_thread_fence(memory_order_release);
> 
>   pony_msg_t* prev = atomic_exchange_explicit(&q->head, last,
>     memory_order_relaxed);
> 
>   bool was_empty = ((uintptr_t)prev & 1) != 0;
>   prev = (pony_msg_t*)((uintptr_t)prev & ~(uintptr_t)1);
> 
> #ifdef USE_VALGRIND
>   // Double fence with Valgrind since we need to have prev in scope for the
>   // synchronisation annotation.
>   ANNOTATE_HAPPENS_BEFORE(&prev->next);
>   atomic_thread_fence(memory_order_release);
> #endif
>   atomic_store_explicit(&prev->next, first, memory_order_relaxed);
> 
>   return was_empty;
> }
> 
> void ponyint_messageq_init(messageq_t* q)
> {
>   pony_msg_t* stub = POOL_ALLOC(pony_msg_t);
>   stub->index = POOL_INDEX(sizeof(pony_msg_t));
>   atomic_store_explicit(&stub->next, NULL, memory_order_relaxed);
> 
>   atomic_store_explicit(&q->head, (pony_msg_t*)((uintptr_t)stub | 1),
>     memory_order_relaxed);
>   q->tail = stub;
> 
> #ifndef PONY_NDEBUG
>   messageq_size_debug(q);
> #endif
> }
> 
> pony_msg_t* ponyint_thread_messageq_pop(messageq_t* q
> #ifdef USE_DYNAMIC_TRACE
>   , uintptr_t thr
> #endif
>   )
> {
>   pony_msg_t* tail = q->tail;
>   pony_msg_t* next = atomic_load_explicit(&tail->next, memory_order_relaxed);
> 
>   if(next != NULL)
>   {
>     DTRACE2(THREAD_MSG_POP, (uint32_t) next->id, (uintptr_t) thr);
>     q->tail = next;
>     atomic_thread_fence(memory_order_acquire);
> #ifdef USE_VALGRIND
>     ANNOTATE_HAPPENS_AFTER(&tail->next);
>     ANNOTATE_HAPPENS_BEFORE_FORGET_ALL(tail);
> #endif
>     ponyint_pool_free(tail->index, tail);
>   }
> 
>   return next;
> }
> 
> bool ponyint_messageq_markempty(messageq_t* q)
> {
>   pony_msg_t* tail = q->tail;
>   pony_msg_t* head = atomic_load_explicit(&q->head, memory_order_relaxed);
> 
>   if(((uintptr_t)head & 1) != 0)
>     return true;
> 
>   if(head != tail)
>     return false;
> 
>   head = (pony_msg_t*)((uintptr_t)head | 1);
> 
> #ifdef USE_VALGRIND
>   ANNOTATE_HAPPENS_BEFORE(&q->head);
> #endif
>   return atomic_compare_exchange_strong_explicit(&q->head, &tail, head,
>     memory_order_release, memory_order_relaxed);
> }
> ```
> 
> However, I probably have missed something here but it seems to me like:
> - The back of the queue (head in Pony) is never modified in the enqueue/pop routines.
>   This is problematic as it would still points to the item that was just dequeued
> - In snmalloc the queue front is overwritten by next, meaning the initial dummy node would be overwritten on first dequeue. But its memory is never freed/recycled.
> - As they both erase the front in the dequeue/pop, but the dequeuing only advances when there is more than one item in the queue, the consumer will get blocked on the last message.
> - Snmalloc keeps an atomic count of enqueued objects next to the queue.
>   In our case, both for the memory pool and for steal requests (for the adaptative steal strategy) we also need to keep an approximate count of enqueued items, we might as well integrate it in the queue.
> 
> 
> 
