### PR TITLE
C++ compatibility

### DIFF
--- a/weave/memory/lookaside_lists.nim
+++ b/weave/memory/lookaside_lists.nim
@@ -140,7 +140,7 @@ proc cacheMaintenanceEx[T](lal: ptr LookAsideList[T]) =
 
 proc setCacheMaintenanceEx*[T](hook: var tuple[onHeartbeat: proc(env: pointer){.nimcall.}, env: pointer],
                  lal: var LookAsideList[T]) {.inline.} =
-  hook.onHeartbeat = cast[proc(env: pointer) {.nimcall.}](cacheMaintenanceEx[T])
+  hook.onHeartbeat = cast[typeof hook.onHeartbeat](cacheMaintenanceEx[T])
   hook.env = lal.addr
 
   lal.registeredAt = hook.addr


### PR DESCRIPTION
We had to remove the attempt to avoid monomorphization code bloat in the ptr channels. As they were inline for every procedure and only used for the Task type anyway it probably doesn't change anything regarding code size.