### PR TITLE
Me 1 - 0 Glibc: replace buggy Glibc condvar by futex

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,11 @@
+# Changelog
+
+
+### v0.2.0
+
+Backoff has been renamed from `WV_EnableBackoff` to `WV_Backoff`.
+It is now enabled by default.
+
+### v0.1.0
+
+Initial release

--- a/weave/channels/event_notifiers.nim
+++ b/weave/channels/event_notifiers.nim
@@ -113,7 +113,7 @@ func prepareToPark*(en: var EventNotifier) {.inline.} =
   if not en.signaled.load(moRelaxed):
     en.ticket = en.phase.load(moRelaxed)
 
-func park*(en: var EventNotifier) {.inline.} =
+proc park*(en: var EventNotifier) {.inline.} =
   ## Wait until we are signaled of an event
   ## Thread is parked and does not consume CPU resources
   ## This may wakeup spuriously.
@@ -128,7 +128,7 @@ func park*(en: var EventNotifier) {.inline.} =
     en.futex.initialize()
   # We still hold the lock but it's not used anyway.
 
-func notify*(en: var EventNotifier) {.inline.} =
+proc notify*(en: var EventNotifier) {.inline.} =
   ## Signal a thread that it can be unparked
 
   if en.signaled.load(moRelaxed):

--- a/weave/config.nim
+++ b/weave/config.nim
@@ -59,7 +59,7 @@ const WV_StealEarly* {.intdefine.} = 0
   ## steal requests in advance. This might help hide stealing latencies
   ## or worsen message overhead.
 
-const WV_EnableBackoff* {.booldefine.} = false
+const WV_Backoff* {.booldefine.} = true
   ## Workers that fail to find work will sleep. This saves CPU at the price
   ## of slight latency as the workers' parent nodes need to manage their
   ## steal requests queues when they sleep and there is latency to wake up.
@@ -110,7 +110,7 @@ template EagerFV*(body: untyped): untyped =
     body
 
 template Backoff*(body: untyped): untyped =
-  when WV_EnableBackoff:
+  when WV_Backoff:
     body
 
 # Dynamic defines

--- a/weave/datatypes/context_global.nim
+++ b/weave/datatypes/context_global.nim
@@ -13,7 +13,7 @@ import
   ../primitives/barriers,
   ./sync_types, ./binary_worker_trees
 
-when WV_EnableBackoff:
+when WV_Backoff:
   import ../channels/event_notifiers
 
 # Global / inter-thread communication channels
@@ -38,7 +38,7 @@ type
     # Theft channels are bounded to "NumWorkers * WV_MaxConcurrentStealPerWorker"
     thefts*: ptr UncheckedArray[ChannelMpscUnboundedBatch[StealRequest]]
     tasks*: ptr UncheckedArray[Persistack[WV_MaxConcurrentStealPerWorker, ChannelSpscSinglePtr[Task]]]
-    when static(WV_EnableBackoff):
+    when static(WV_Backoff):
       parking*: ptr UncheckedArray[EventNotifier]
 
   GlobalContext* = object

--- a/weave/primitives/futex_linux.nim
+++ b/weave/primitives/futex_linux.nim
@@ -12,35 +12,15 @@
 import std/atomics, ../instrumentation/loggers
 export MemoryOrder
 
-const
-  NR_Futex = 202
-  FutexPrivateFlag = 128
-
 type
   Futex* = distinct Atomic[int32]
+  FutexOp = distinct cint
 
-  FutexOp {.size: sizeof(cint).}= enum
-    FutexWait = 0
-    FutexWake = 1
-    # ...
-    FutexWaitPrivate = 0 or FutexPrivateFlag # If all threads belong to the same process
-    FutexWakePrivate = 1 or FutexPrivateFlag # If all threads belong to the same process
-
-when not defined(release) or not defined(danger):
-  var SysFutexDbg {.importc:"SYS_futex", header: "<sys/syscall.h>".}: cint
-  assert NR_Futex == SysFutexDbg, "Your platform is misconfigured"
-
-  var FutexWaitDbg {.importc:"FUTEX_WAIT", header: "<linux/futex.h>".}: cint
-  assert ord(FutexWait) == FutexWaitDbg, "Your platform is misconfigured"
-
-  var FutexWakeDbg {.importc:"FUTEX_WAKE", header: "<linux/futex.h>".}: cint
-  assert ord(FutexWake) == FutexWakeDbg, "Your platform is misconfigured"
-
-  var FutexWaitPrivateDbg {.importc:"FUTEX_WAIT_PRIVATE", header: "<linux/futex.h>".}: cint
-  assert ord(FutexWaitPrivate) == FutexWaitPrivateDbg, "Your platform is misconfigured"
-
-  var FutexWakePrivateDbg {.importc:"FUTEX_WAKE_PRIVATE", header: "<linux/futex.h>".}: cint
-  assert ord(FutexWakePrivate) == FutexWakePrivateDbg, "Your platform is misconfigured"
+var NR_Futex {.importc: "__NR_futex", header: "<sys/syscall.h>".}: cint
+var FutexWait {.importc: "FUTEX_WAIT", header:"<linux/futex.h>".}: FutexOp
+var FutexWake {.importc:"FUTEX_WAKE", header: "<linux/futex.h>".}: FutexOp
+var FutexWaitPrivate {.importc:"FUTEX_WAIT_PRIVATE", header: "<linux/futex.h>".}: FutexOp
+var FutexWakePrivate {.importc:"FUTEX_WAKE_PRIVATE", header: "<linux/futex.h>".}: FutexOp
 
 proc syscall(sysno: clong): cint {.header:"<sys/syscall.h>", varargs.}
 

--- a/weave/primitives/futex_linux.nim
+++ b/weave/primitives/futex_linux.nim
@@ -1,0 +1,71 @@
+# Weave
+# Copyright (c) 2019 Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# A wrapper for linux futex.
+# Condition variables do not always wake on signal which can deadlock the runtime
+# so we need to roll up our sleeves and use the low-level futex API.
+
+import std/atomics, ../instrumentation/loggers
+export MemoryOrder
+
+const
+  NR_Futex = 202
+  FutexPrivateFlag = 128
+
+type
+  Futex* = distinct Atomic[int32]
+
+  FutexOp {.size: sizeof(cint).}= enum
+    FutexWait = 0
+    FutexWake = 1
+    # ...
+    FutexWaitPrivate = 0 or FutexPrivateFlag # If all threads belong to the same process
+    FutexWakePrivate = 1 or FutexPrivateFlag # If all threads belong to the same process
+
+when not defined(release) or not defined(danger):
+  var SysFutexDbg {.importc:"SYS_futex", header: "<sys/syscall.h>".}: cint
+  assert NR_Futex == SysFutexDbg, "Your platform is misconfigured"
+
+  var FutexWaitDbg {.importc:"FUTEX_WAIT", header: "<linux/futex.h>".}: cint
+  assert ord(FutexWait) == FutexWaitDbg, "Your platform is misconfigured"
+
+  var FutexWakeDbg {.importc:"FUTEX_WAKE", header: "<linux/futex.h>".}: cint
+  assert ord(FutexWake) == FutexWakeDbg, "Your platform is misconfigured"
+
+  var FutexWaitPrivateDbg {.importc:"FUTEX_WAIT_PRIVATE", header: "<linux/futex.h>".}: cint
+  assert ord(FutexWaitPrivate) == FutexWaitPrivateDbg, "Your platform is misconfigured"
+
+  var FutexWakePrivateDbg {.importc:"FUTEX_WAKE_PRIVATE", header: "<linux/futex.h>".}: cint
+  assert ord(FutexWakePrivate) == FutexWakePrivateDbg, "Your platform is misconfigured"
+
+proc syscall(sysno: clong): cint {.header:"<sys/syscall.h>", varargs.}
+
+proc sysFutex(
+       futex: var Futex, op: FutexOp, val1: cint,
+       timeout: pointer = nil, val2: pointer = nil, val3: cint = 0): cint {.inline.} =
+  syscall(NR_Futex, futex.addr, op, val1, timeout, val2, val3)
+
+proc wait*(futex: var Futex, refVal: int32): cint {.inline.} =
+  ## Suspend a thread if the value of the futex is the same as refVal.
+  ## Returns 0 in case of a successful suspend
+  ## If value are different, it returns EWOULDBLOCK
+  sysFutex(futex, FutexWaitPrivate, refVal)
+
+proc wake*(futex: var Futex): cint {.inline.} =
+  ## Wake one thread (from the same process)
+  ## Returns the number of actually woken thread
+  ## or a Posix error code (if negative)
+  sysFutex(futex, FutexWakePrivate, 1)
+
+proc load*(futex: var Futex, memOrder: MemoryOrder): int32 {.inline.} =
+  Atomic[int32](futex).load(memOrder)
+
+proc store*(futex: var Futex, val: int32, memOrder: MemoryOrder) {.inline.} =
+  Atomic[int32](futex).store(val, memOrder)
+
+proc initialize*(futex: var Futex) {.inline.} =
+  futex.store(0, moRelaxed)

--- a/weave/primitives/futex_linux.nim
+++ b/weave/primitives/futex_linux.nim
@@ -13,7 +13,7 @@ import std/atomics, ../instrumentation/loggers
 export MemoryOrder
 
 type
-  Futex* = distinct Atomic[int32]
+  Futex* = Atomic[int32]
   FutexOp = distinct cint
 
 var NR_Futex {.importc: "__NR_futex", header: "<sys/syscall.h>".}: cint

--- a/weave/primitives/futex_linux.nim
+++ b/weave/primitives/futex_linux.nim
@@ -22,7 +22,7 @@ var FutexWake {.importc:"FUTEX_WAKE", header: "<linux/futex.h>".}: FutexOp
 var FutexWaitPrivate {.importc:"FUTEX_WAIT_PRIVATE", header: "<linux/futex.h>".}: FutexOp
 var FutexWakePrivate {.importc:"FUTEX_WAKE_PRIVATE", header: "<linux/futex.h>".}: FutexOp
 
-proc syscall(sysno: clong): cint {.header:"<sys/syscall.h>", varargs.}
+proc syscall(sysno: clong): cint {.header:"<unistd.h>", varargs.}
 
 proc sysFutex(
        futex: var Futex, op: FutexOp, val1: cint,
@@ -41,11 +41,12 @@ proc wake*(futex: var Futex): cint {.inline.} =
   ## or a Posix error code (if negative)
   sysFutex(futex, FutexWakePrivate, 1)
 
-proc load*(futex: var Futex, memOrder: MemoryOrder): int32 {.inline.} =
-  Atomic[int32](futex).load(memOrder)
-
-proc store*(futex: var Futex, val: int32, memOrder: MemoryOrder) {.inline.} =
-  Atomic[int32](futex).store(val, memOrder)
+# Futex is not a distinct Atomic[int32] due to bad codegen with C++
+# proc load*(futex: var Futex, memOrder: MemoryOrder): int32 {.inline.} =
+#   Atomic[int32](futex).load(memOrder)
+#
+# proc store*(futex: var Futex, val: int32, memOrder: MemoryOrder) {.inline.} =
+#   Atomic[int32](futex).store(val, memOrder)
 
 proc initialize*(futex: var Futex) {.inline.} =
   futex.store(0, moRelaxed)


### PR DESCRIPTION
This replaces Lock+Condition variables by futex on Linux.

It solves the nasty #56 bug which is due to a Glibc and Musl bug on condvar signaling not waking up all thread.

Would be nice to use futex on Windows as well as they are supported there and are much more lightweight than condition variables + lock (4 bytes vs ~72 bytes on Linux) plus we don't need all the extra fluff that mutexes and condition variables have to guard against as we have formally verified that just wait+wake is enough.