### PR TITLE
No syscall portable threadid

### DIFF
--- a/weave/channels/channels_spsc_single.nim
+++ b/weave/channels/channels_spsc_single.nim
@@ -161,7 +161,7 @@ when isMainModule:
     echo "-----------------------------------"
     var threads: array[2, Thread[ThreadArgs]]
     var pool: TLPoolAllocator
-    pool.initialize(threadID = 0)
+    pool.initialize()
 
     var chan = pool.borrow(ChannelSPSCSingle)
     chan[].initialize(itemSize = sizeof(int))
@@ -172,7 +172,7 @@ when isMainModule:
     joinThread(threads[0])
     joinThread(threads[1])
 
-    recycle(0, chan)
+    recycle(chan)
 
     echo "-----------------------------------"
     echo "Success"

--- a/weave/contexts.nim
+++ b/weave/contexts.nim
@@ -116,7 +116,7 @@ proc newTaskFromCache*(): Task =
 
 proc delete*(task: Task) {.inline.} =
   preCondition: not task.isNil()
-  recycle(myID(), task)
+  recycle(task)
 
 iterator items(t: Task): Task =
   var cur = t
@@ -128,7 +128,7 @@ iterator items(t: Task): Task =
 proc flushAndDispose*(dq: var PrellDeque) =
   let leftovers = flush(dq)
   for task in items(leftovers):
-    recycle(myID(), task)
+    recycle(task)
 
 # Dynamic Scopes
 # ----------------------------------------------------------------------------------

--- a/weave/datatypes/flowvars.nim
+++ b/weave/datatypes/flowvars.nim
@@ -84,7 +84,7 @@ EagerFV:
     ## From the parent thread awaiting on the result, force its computation
     ## by eagerly processing only the child tasks spawned by the awaited task
     fv.forceFuture(parentResult)
-    recycle(myID(), fv.chan)
+    recycle(fv.chan)
 
 LazyFV:
   # Templates everywhere as we use alloca
@@ -113,7 +113,7 @@ LazyFV:
       parentResult = cast[ptr T](fv.lfv.lazy.buf.addr)[]
     else:
       ascertain: not fv.lfv.lazy.chan.isNil
-      recycle(myID(), fv.lfv.lazy.chan)
+      recycle(fv.lfv.lazy.chan)
 
   import sync_types
 
@@ -158,8 +158,8 @@ proc recycleFVN*(fvNode: sink FlowvarNode) {.inline.} =
   ## This assumes that the channel was already recycled
   ## by a "sync"/"forceComplete"
   LazyFV:
-    recycle(myID(), fvNode.lfv)
-  recycle(myID(), fvNode)
+    recycle(fvNode.lfv)
+  recycle(fvNode)
 
 
 # TODO destructors for automatic management

--- a/weave/datatypes/prell_deques.nim
+++ b/weave/datatypes/prell_deques.nim
@@ -320,7 +320,7 @@ when isMainModule:
 
   var pool: TLPoolAllocator
 
-  pool.initialize(threadID = 0)
+  pool.initialize()
 
   proc newTask(cache: var LookAsideList[Task]): Task =
     result = cache.pop()
@@ -329,7 +329,7 @@ when isMainModule:
     zeroMem(result, sizeof(deref(Task)))
 
   proc delete(task: Task) =
-    recycle(myThreadID = 0'i32, task)
+    recycle(task)
 
   iterator items(t: Task): Task =
     var cur = t
@@ -340,12 +340,11 @@ when isMainModule:
 
   proc recycleAll(taskList: sink Task) =
     for task in taskList:
-      recycle(myThreadID = 0'i32, task)
+      recycle(task)
 
   suite "Testing PrellDeques":
     var deq: PrellDeque[Task]
     var cache: LookAsideList[Task]
-    # cache.threadID = 0
     # cache.freeFn = recycle
     # pool.hook.setHeartbeat(cache)
 
@@ -408,7 +407,6 @@ when isMainModule:
         var deq2: PrellDeque[Task]
         deq2.initialize()
         var cache2: LookAsideList[Task]
-        cache2.threadID = 1
         cache2.freeFn = recycle
 
         deq2.addListFirst(head, tail, numStolen)

--- a/weave/memory/thread_id.nim
+++ b/weave/memory/thread_id.nim
@@ -1,0 +1,56 @@
+# Weave
+# Copyright (c) 2019 Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# Fast unique thread ID
+# This gives unique thread ID suitable for memory allocators.
+# Those IDs are not suitable for the Weave runtime
+# as for that case, the ID should be the range 0 ..< Weave_NUM_THREADS
+# to allow the common pattern or indexing an array by a thread ID.
+
+when (defined(gcc) or defined(clang) or defined(llvm_gcc)) and
+  (defined(i386) or defined(amd64) or defined(arm) or defined(arm64)):
+
+  func getMemThreadID*(): int {.inline.} =
+    ## Returns a unique thread-local identifier.
+    ## This is suitable for memory allocator thread-local identifier
+    ## and never requires an expensive syscall.
+    # Thread-Local-Storage register on x86 is in the FS or GS register
+    # see: https://akkadia.org/drepper/tls.pdf
+    when defined(i386):
+      asm """
+        movl %%gs:0, %0:"=r"(`result`)::"""
+    elif defined(osx):
+      asm """
+        movq %%gs:0, %0:"=r"(`result`)::"""
+    elif defined(amd64):
+      asm """
+        movq %%fs:0, %0:"=r"(`result`)::"""
+    elif defined(arm):
+      {.emit: ["""asm volatile(
+        "mrc p15, 0, %0, c13, c0, 3"
+        :"=r"(""", result, """)
+      );"""].}
+    elif defined(arm64):
+      {.emit: ["""asm volatile("mrs %0, tpidr_el0":"=r"(""",result,"));"].}
+    else:
+      {.error: "Unreachable".}
+elif defined(windows):
+  proc NtcurrentTeb(): int {.importc, cdecl, header:"<windows.h>".}
+    ## Get pointer to Thread Environment BLock
+    # Note that ntdll.dll exports this as stdcall but it's a cdecl ¯\_(ツ)_/¯
+
+  func getMemThreadID*(): int {.inline.} =
+    ## Returns a unique thread-local identifier.
+    ## This is suitable for memory allocator thread-local identifier
+    ## and never requires an expensive syscall.
+    NtcurrentTeb()
+else:
+  var dummy {.threadvar.}: byte
+
+  func getMemThreadID*(): int {.inline.} =
+    {.noSideEffect.}:
+      cast[ByteAddress](dummy.addr)

--- a/weave/memory/thread_id.nim
+++ b/weave/memory/thread_id.nim
@@ -22,13 +22,13 @@ when (defined(gcc) or defined(clang) or defined(llvm_gcc)) and
     # see: https://akkadia.org/drepper/tls.pdf
     when defined(i386):
       asm """
-        movl %%gs:0, %0:"=r"(`result`)::"""
+        "movl %%gs:0, %0":"=r"(`result`)::"""
     elif defined(osx):
       asm """
-        movq %%gs:0, %0:"=r"(`result`)::"""
+        "movq %%gs:0, %0":"=r"(`result`)::"""
     elif defined(amd64):
       asm """
-        movq %%fs:0, %0:"=r"(`result`)::"""
+        "movq %%fs:0, %0":"=r"(`result`)::"""
     elif defined(arm):
       {.emit: ["""asm volatile(
         "mrc p15, 0, %0, c13, c0, 3"

--- a/weave/memory/thread_id.nim
+++ b/weave/memory/thread_id.nim
@@ -39,9 +39,8 @@ when (defined(gcc) or defined(clang) or defined(llvm_gcc)) and
     else:
       {.error: "Unreachable".}
 elif defined(windows):
-  proc NtcurrentTeb(): int {.importc, cdecl, header:"<windows.h>".}
+  proc NtcurrentTeb(): int {.importc, stdcall, dynlib:"ntdll".}
     ## Get pointer to Thread Environment BLock
-    # Note that ntdll.dll exports this as stdcall but it's a cdecl ¯\_(ツ)_/¯
 
   func getMemThreadID*(): int {.inline.} =
     ## Returns a unique thread-local identifier.

--- a/weave/runtime.nim
+++ b/weave/runtime.nim
@@ -64,7 +64,7 @@ proc init*(_: type Weave) =
     #       Note that while 2x siblings is common, Xeon Phi has 4x Hyper-Threading.
     pinToCpu(globalCtx.threadpool[i], i)
 
-  myMemPool().initialize(myID())
+  myMemPool().initialize()
   myWorker().currentTask = newTaskFromCache() # Root task
   init(localCtx)
   # Wait for the child threads

--- a/weave/scheduler.nim
+++ b/weave/scheduler.nim
@@ -75,7 +75,7 @@ proc init*(ctx: var TLContext) {.gcsafe.} =
   ctx.runtimeIsQuiescent = false
   ctx.signaledTerminate = false
 
-  ctx.taskCache.initialize(tID = myID(), freeFn = memory_pools.recycle)
+  ctx.taskCache.initialize(freeFn = memory_pools.recycle)
   myMemPool.hook.setCacheMaintenanceEx(ctx.taskCache)
 
   # Worker
@@ -241,7 +241,7 @@ proc worker_entry_fn*(id: WorkerID) {.gcsafe.} =
   preCondition: localCtx == default(TLContext)
 
   myID() = id # If this crashes, you need --tlsemulation:off
-  myMemPool().initialize(myID())
+  myMemPool().initialize()
   localCtx.init()
   discard globalCtx.barrier.wait()
 


### PR DESCRIPTION
This fixes #42.

The memory pool requires an unique ThreadID to identify if the memory being recycled can use the fast-path because it is thread-local or use a slow thread-safe recycling path.

However usual ways of getting a unique threadID via pthread_self or GetThreadID requires a syscall, which are **very** expensive (100 of cycles at the very least) and a complete non-starter.

Previously this required all data structures that to remember a threadID, and pass it when recycling memory, now the memory pool ha sthe same API as regular malloc/free.

This instead uses the address of the thread-local storage as an unique ID and only requires 1 cycle provided the function is inlined.

