### PR TITLE
Strided loop splitting bug

### DIFF
--- a/benchmarks/matrix_transposition/openmp_transposes.nim
+++ b/benchmarks/matrix_transposition/openmp_transposes.nim
@@ -243,7 +243,7 @@ template runBench(transposeName: typed, reorderCompute: bool): untyped =
 # Interface
 # ---------------------------------------------------
 
-proc main(M = 400, N = 4000, nrounds = 10000, transposeStrat = TiledCollapsed, reorderCompute=false) =
+proc main(M = 400, N = 4000, nrounds = 1000, transposeStrat = TiledCollapsed, reorderCompute=false) =
   echo "Inverting the transpose order may favor one transposition heavily for non-tiled strategies"
 
   let nthreads = if transposeStrat == Sequential: 1'i32

--- a/weave/loop_splitting.nim
+++ b/weave/loop_splitting.nim
@@ -44,21 +44,20 @@ func roundPrevMultipleOf(x: SomeInteger, step: SomeInteger): SomeInteger {.inlin
 
 func splitAdaptative(task: Task, approxNumThieves: int32): int {.inline.} =
   ## Split iteration range based on the number of steal requests
-  let itersLeft = (task.stop - task.cur + task.stride-1) div task.stride
-  preCondition: itersLeft > 1
+  let chunksLeft = (task.stop - task.cur + task.stride-1) div task.stride
+  preCondition: chunksLeft > 1
 
   debug:
-    log("Worker %2d: %ld iterations left (start: %d, current: %d, stop: %d, stride: %d, %d thieves)\n",
-      myID(), iters_left, task.start, task.cur, task.stop, task.stride, approxNumThieves)
+    log("Worker %2d: %ld chunks left (start: %d, current: %d, stop: %d, stride: %d, %d thieves)\n",
+      myID(), chunksLeft, task.start, task.cur, task.stop, task.stride, approxNumThieves)
 
   # Send a chunk of work to all
-  let chunk = max(itersLeft div (approxNumThieves + 1), 1)
+  let chunk = max(chunksLeft div (approxNumThieves + 1), 1)
 
   postCondition:
-    itersLeft > chunk
+    chunksLeft > chunk
 
-  debug: log("Worker %2d: sending %ld iterations\n", myID(), chunk*task.stride)
-  return roundPrevMultipleOf(task.stop - chunk*task.stride, chunk*task.stride)
+  result = roundPrevMultipleOf(task.stop - chunk*task.stride, task.stride)
 
 template split*(task: Task, approxNumThieves: int32): int =
   when SplitStrategy == SplitKind.half:

--- a/weave/parallel_for.nim
+++ b/weave/parallel_for.nim
@@ -142,55 +142,55 @@ macro parallelForStrided*(loopParams: untyped, stride: Positive, body: untyped):
 when isMainModule:
   import ./instrumentation/loggers, ./runtime, ./runtime_fsm
 
-  block:
-    proc main() =
-      init(Weave)
+  # block:
+  #   proc main() =
+  #     init(Weave)
 
-      parallelFor i in 0 ..< 100:
-        log("%d (thread %d)\n", i, myID())
+  #     parallelFor i in 0 ..< 100:
+  #       log("%d (thread %d)\n", i, myID())
 
-      exit(Weave)
+  #     exit(Weave)
 
-    echo "Simple parallel for"
-    echo "-------------------------"
-    main()
-    echo "-------------------------"
+  #   echo "Simple parallel for"
+  #   echo "-------------------------"
+  #   main()
+  #   echo "-------------------------"
 
-  block: # Capturing outside scope
-    proc main2() =
-      init(Weave)
+  # block: # Capturing outside scope
+  #   proc main2() =
+  #     init(Weave)
 
-      var a = 100
-      var b = 10
-      # expandMacros:
-      parallelFor i in 0 ..< 10:
-        captures: {a, b}
-        log("a+b+i = %d (thread %d)\n", a+b+i, myID())
+  #     var a = 100
+  #     var b = 10
+  #     # expandMacros:
+  #     parallelFor i in 0 ..< 10:
+  #       captures: {a, b}
+  #       log("a+b+i = %d (thread %d)\n", a+b+i, myID())
 
-      exit(Weave)
-
-
-    echo "\n\nCapturing outside variables"
-    echo "-------------------------"
-    main2()
-    echo "-------------------------"
+  #     exit(Weave)
 
 
-  block: # Nested loops
-    proc main3() =
-      init(Weave)
+  #   echo "\n\nCapturing outside variables"
+  #   echo "-------------------------"
+  #   main2()
+  #   echo "-------------------------"
 
-      parallelFor i in 0 ..< 4:
-        parallelFor j in 0 ..< 8:
-          captures: {i}
-          log("Matrix[%d, %d] (thread %d)\n", i, j, myID())
 
-      exit(Weave)
+  # block: # Nested loops
+  #   proc main3() =
+  #     init(Weave)
 
-    echo "\n\nNested loops"
-    echo "-------------------------"
-    main3()
-    echo "-------------------------"
+  #     parallelFor i in 0 ..< 4:
+  #       parallelFor j in 0 ..< 8:
+  #         captures: {i}
+  #         log("Matrix[%d, %d] (thread %d)\n", i, j, myID())
+
+  #     exit(Weave)
+
+  #   echo "\n\nNested loops"
+  #   echo "-------------------------"
+  #   main3()
+  #   echo "-------------------------"
 
 
   block: # Strided Nested loops
@@ -198,8 +198,8 @@ when isMainModule:
       init(Weave)
 
       # expandMacros:
-      parallelForStrided i in 0 ..< 100, stride = 30:
-        parallelForStrided j in 0 ..< 200, stride = 60:
+      parallelForStrided i in 0 ..< 500, stride = 30:
+        parallelForStrided j in 0 ..< 1000, stride = 60:
           captures: {i}
           log("Matrix[%d, %d] (thread %d)\n", i, j, myID())
 


### PR DESCRIPTION
We were sending `roundPrevMultipleOf(task.stop - chunk*task.stride, chunk*task.stride)` instead of `roundPrevMultipleOf(task.stop - chunk*task.stride, task.stride)` for strided loop which often meant sending everything and having no tasks left.