### PR TITLE
Reduce metadata in task descriptor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,16 +32,13 @@ matrix:
         - CHANNEL=devel
       compiler: clang
 
-    # OSX tests for Travis are very strange. A non-root task
-    # can end up in a root barrier even when there is no nested parallelism
-    # TODO: https://github.com/mratsim/weave/issues/51
     # On OSX we only test against clang (gcc is mapped to clang by default)
-    # - os: osx
-    #   arch: amd64
-    #   env:
-    #     - ARCH=amd64
-    #     - CHANNEL=devel
-    #   compiler: clang
+    - os: osx
+      arch: amd64
+      env:
+        - ARCH=amd64
+        - CHANNEL=devel
+      compiler: clang
   fast_finish: true
 
 before_install:

--- a/experiments/e04_channel_based_work_stealing/runtime.nim
+++ b/experiments/e04_channel_based_work_stealing/runtime.nim
@@ -616,7 +616,6 @@ proc async_action(fn: proc (_: pointer) {.nimcall.}, chan: Channel[Task]) =
   profile(send_recv_task):
     let dummy = task_alloc()
     dummy.fn = fn
-    dummy.batch = 1
     when defined(StealLastVictim):
       dummy.victim = -1
 

--- a/weave.nimble
+++ b/weave.nimble
@@ -40,14 +40,12 @@ task test, "Run Weave tests":
   test "", "weave/memory/persistacks.nim"
 
   test "", "weave/parallel_tasks.nim"
-  when defined(linux): # Need nestable barriers - https://github.com/mratsim/weave/issues/51
-    test "", "weave/parallel_for.nim"
+  test "", "weave/parallel_for.nim"
   test "", "weave/parallel_for_staged.nim"
   # test "", "weave/parallel_reduce.nim"
 
   test "-d:WV_LazyFlowvar", "weave/parallel_tasks.nim"
-  when defined(linux):
-    test "-d:WV_LazyFlowvar", "weave/parallel_for.nim"
+  test "-d:WV_LazyFlowvar", "weave/parallel_for.nim"
   test "-d:WV_LazyFlowvar", "weave/parallel_for_staged.nim"
   # test "-d:WV_LazyFlowvar", "weave/parallel_reduce.nim" # Experimental
 

--- a/weave/await_fsm.nim
+++ b/weave/await_fsm.nim
@@ -148,11 +148,10 @@ behavior(awaitFSA):
     ascertain: not task.fn.isNil
     debug: log("Worker %2d: forcefut 3 - stoled tasks\n", myID())
 
-    let loot = task.batch
-    if loot > 1:
+    if not task.next.isNil:
       profile(enq_deq_task):
         # Add everything
-        myWorker().deque.addListFirst(task, loot)
+        myWorker().deque.addListFirst(task)
         # And then only use the last
         task = myWorker().deque.popFirst()
 

--- a/weave/contexts.nim
+++ b/weave/contexts.nim
@@ -110,7 +110,6 @@ proc newTaskFromCache*(): Task =
   result.stop = 0
   result.stride = 0
   result.futures = nil
-  result.batch = 0
   result.isLoop = false
   result.hasFuture = false
 

--- a/weave/datatypes/prell_deques.nim
+++ b/weave/datatypes/prell_deques.nim
@@ -116,7 +116,7 @@ proc flush*[T: StealableTask](dq: var PrellDeque[T]): T {.inline.} =
 # Batch routines
 # ---------------------------------------------------------------
 
-func addListFirst[T](dq: var PrellDeque[T], head, tail: sink T, len: int32) =
+func addListFirst[T](dq: var PrellDeque[T], head, tail: sink T, len: int32) {.inline.} =
   # Add a list of tasks [head ... tail] of length len to the front of the deque
   preCondition: not head.isNil and not tail.isNil
   preCondition: len > 0
@@ -130,20 +130,16 @@ func addListFirst[T](dq: var PrellDeque[T], head, tail: sink T, len: int32) =
   dq.head = head
   dq.pendingTasks += len
 
-func addListFirst*[T](dq: var PrellDeque[T], head: sink T, len: int32) =
+func addListFirst*[T](dq: var PrellDeque[T], head: sink T) =
   preCondition: not head.isNil
-  preCondition: len > 0
 
   var tail = head
-  when compileOption("boundChecks"):
-    var index = 0'i32
+  var index = 0'i32
   while not tail.next.isNil:
     tail = tail.next
-    when compileOption("boundChecks"):
-      index += 1
+    index += 1
 
-  when compileOption("boundChecks"):
-    postCondition: index + 1 == len
+  let len = index + 1
   dq.addListFirst(head, tail, len)
 
 # Task-specific routines
@@ -235,7 +231,6 @@ template multistealImpl[T](
     dq.tail.prev.next = dq.tail.addr # last task points to dummy
 
   dq.pendingTasks -= numStolen
-  # dq.numSteals += 1
 
 func stealMany*[T](dq: var PrellDeque[T],
                   maxSteals: int32, # should be range[1'i32 .. high(int32)]

--- a/weave/datatypes/sync_types.nim
+++ b/weave/datatypes/sync_types.nim
@@ -46,10 +46,9 @@ type
     futureSize*: uint8 # Size of the future result type if relevant
     # 79 bytes
     # User data - including the FlowVar channel to send back result.
-    data*: array[TaskDataSize, byte]
-
-    # TODO: support loops with steps
-
+    # It is very likely that User data contains a pointer (the Flowvar channel)
+    # We align to avoid torn reads/extra bookkeeping.
+    data*{.align:sizeof(int).}: array[TaskDataSize, byte]
 
   # Steal requests
   # ----------------------------------------------------------------------------------

--- a/weave/datatypes/sync_types.nim
+++ b/weave/datatypes/sync_types.nim
@@ -40,7 +40,6 @@ type
     stride*: int
     # 64 bytes
     futures*: pointer  # LinkedList of futures required by the current task
-    batch*: int32      # TODO remove
     isLoop*: bool
     hasFuture*: bool   # If a task is associated with a future, the future is stored at data[0]
     futureSize*: uint8 # Size of the future result type if relevant

--- a/weave/parallel_for.nim
+++ b/weave/parallel_for.nim
@@ -142,64 +142,63 @@ macro parallelForStrided*(loopParams: untyped, stride: Positive, body: untyped):
 when isMainModule:
   import ./instrumentation/loggers, ./runtime, ./runtime_fsm
 
-  # block:
-  #   proc main() =
-  #     init(Weave)
+  block:
+    proc main() =
+      init(Weave)
 
-  #     parallelFor i in 0 ..< 100:
-  #       log("%d (thread %d)\n", i, myID())
+      parallelFor i in 0 ..< 100:
+        log("%d (thread %d)\n", i, myID())
 
-  #     exit(Weave)
+      exit(Weave)
 
-  #   echo "Simple parallel for"
-  #   echo "-------------------------"
-  #   main()
-  #   echo "-------------------------"
+    echo "Simple parallel for"
+    echo "-------------------------"
+    main()
+    echo "-------------------------"
 
-  # block: # Capturing outside scope
-  #   proc main2() =
-  #     init(Weave)
+  block: # Capturing outside scope
+    proc main2() =
+      init(Weave)
 
-  #     var a = 100
-  #     var b = 10
-  #     # expandMacros:
-  #     parallelFor i in 0 ..< 10:
-  #       captures: {a, b}
-  #       log("a+b+i = %d (thread %d)\n", a+b+i, myID())
+      var a = 100
+      var b = 10
+      # expandMacros:
+      parallelFor i in 0 ..< 10:
+        captures: {a, b}
+        log("a+b+i = %d (thread %d)\n", a+b+i, myID())
 
-  #     exit(Weave)
-
-
-  #   echo "\n\nCapturing outside variables"
-  #   echo "-------------------------"
-  #   main2()
-  #   echo "-------------------------"
+      exit(Weave)
 
 
-  # block: # Nested loops
-  #   proc main3() =
-  #     init(Weave)
+    echo "\n\nCapturing outside variables"
+    echo "-------------------------"
+    main2()
+    echo "-------------------------"
 
-  #     parallelFor i in 0 ..< 4:
-  #       parallelFor j in 0 ..< 8:
-  #         captures: {i}
-  #         log("Matrix[%d, %d] (thread %d)\n", i, j, myID())
 
-  #     exit(Weave)
+  block: # Nested loops
+    proc main3() =
+      init(Weave)
 
-  #   echo "\n\nNested loops"
-  #   echo "-------------------------"
-  #   main3()
-  #   echo "-------------------------"
+      parallelFor i in 0 ..< 4:
+        parallelFor j in 0 ..< 8:
+          captures: {i}
+          log("Matrix[%d, %d] (thread %d)\n", i, j, myID())
 
+      exit(Weave)
+
+    echo "\n\nNested loops"
+    echo "-------------------------"
+    main3()
+    echo "-------------------------"
 
   block: # Strided Nested loops
     proc main4() =
       init(Weave)
 
       # expandMacros:
-      parallelForStrided i in 0 ..< 500, stride = 30:
-        parallelForStrided j in 0 ..< 1000, stride = 60:
+      parallelForStrided i in 0 ..< 200, stride = 30:
+        parallelForStrided j in 0 ..< 400, stride = 60:
           captures: {i}
           log("Matrix[%d, %d] (thread %d)\n", i, j, myID())
 

--- a/weave/runtime.nim
+++ b/weave/runtime.nim
@@ -65,7 +65,12 @@ proc init*(_: type Weave) =
     pinToCpu(globalCtx.threadpool[i], i)
 
   myMemPool().initialize()
-  myWorker().currentTask = newTaskFromCache() # Root task
+
+  # Root task
+  myWorker().currentTask = newTaskFromCache()
+  myTask().parent = nil
+  myTask().fn = cast[type myTask().fn](0xEFFACED)
+
   init(localCtx)
   # Wait for the child threads
   discard globalCtx.barrier.wait()

--- a/weave/runtime_fsm.nim
+++ b/weave/runtime_fsm.nim
@@ -161,11 +161,10 @@ behavior(syncFSA):
     debug: log("Worker %2d: globalsync 3 - stoled tasks\n", myID())
     ascertain: not task.fn.isNil
 
-    let loot = task.batch
-    if loot > 1:
+    if not task.next.isNil:
       profile(enq_deq_task):
         # Add everything
-        myWorker().deque.addListFirst(task, loot)
+        myWorker().deque.addListFirst(task)
         # And then only use the last
         task = myWorker().deque.popFirst()
 

--- a/weave/scheduler.nim
+++ b/weave/scheduler.nim
@@ -195,10 +195,9 @@ proc schedulingLoop() =
     ascertain: not task.fn.isNil
     debug: log("Worker %2d: schedloop 3 - stoled tasks\n", myID())
 
-    let loot = task.batch
-    if loot > 1:
+    if not task.next.isNil:
       # Add everything
-      myWorker().deque.addListFirst(task, loot)
+      myWorker().deque.addListFirst(task)
       # And then only use the last
       task = myWorker().deque.popFirst()
 

--- a/weave/signals.nim
+++ b/weave/signals.nim
@@ -32,7 +32,6 @@ proc asyncSignal(fn: proc (_: pointer) {.nimcall, gcsafe.}, chan: var ChannelSps
   profile(send_recv_task):
     let dummy = newTaskFromCache()
     dummy.fn = fn
-    dummy.batch = 1
     # TODO: StealLastVictim
 
     let signalSent = chan.trySend(dummy)

--- a/weave/victims.nim
+++ b/weave/victims.nim
@@ -177,6 +177,8 @@ proc dispatchElseDecline*(req: sink StealRequest) {.gcsafe.}=
     let (task, loot) = req.takeTasks()
 
   if not task.isNil:
+    ascertain: not task.fn.isNil
+    ascertain: cast[ByteAddress](task.fn) != 0xFACADE
     profile(send_recv_task):
       # TODO LastVictim
       LazyFV:

--- a/weave/victims.nim
+++ b/weave/victims.nim
@@ -178,7 +178,6 @@ proc dispatchElseDecline*(req: sink StealRequest) {.gcsafe.}=
 
   if not task.isNil:
     profile(send_recv_task):
-      task.batch = loot
       # TODO LastVictim
       LazyFV:
         batchConvertLazyFlowvar(task)
@@ -220,8 +219,6 @@ proc splitAndSend*(task: Task, req: sink StealRequest) =
   debug: log("Worker %2d: Sending [%ld, %ld) to worker %d\n", myID(), upperSplit.start, upperSplit.stop, req.thiefID)
 
   profile(send_recv_task):
-    upperSplit.batch = 1
-
     if upperSplit.hasFuture:
       # The task has a future so it depends on both splitted tasks.
       let fvNode = newFlowvarNode(upperSplit.futureSize)


### PR DESCRIPTION
The batch field is not necessary. Upon received bundled tasks, the thief had to iterate on them to find the tail anyway