### PR TITLE
Victim selection

### DIFF
--- a/benchmarks/xxx_pathological/histogram_2D/weave_histogram.nim
+++ b/benchmarks/xxx_pathological/histogram_2D/weave_histogram.nim
@@ -261,8 +261,9 @@ proc main(matrixSize = 25000'i32, boxes = 1000'i32) =
 
   reportConfig("Sequential", 1, matrixSize, boxes)
   runBench(generateHistogramSerial, matrix, boxes, parallel = false)
-  reportConfig("Weave" & config, nthreads, matrixSize, boxes)
+  reportConfig("Weave - Parallel Reduce" & config, nthreads, matrixSize, boxes)
   runBench(generateHistogramWeaveReduce, matrix, boxes)
+  reportConfig("Weave - Parallel For Staged" & config, nthreads, matrixSize, boxes)
   runBench(generateHistogramWeaveStaged, matrix, boxes)
 
 dispatch(main)

--- a/benchmarks/xxx_pathological/logsumexp/weave_logsumexp.nim
+++ b/benchmarks/xxx_pathological/logsumexp/weave_logsumexp.nim
@@ -314,10 +314,9 @@ proc main(datasetSize = 20000'i64, batchSize = 256'i64, imageLabels = 1000'i64, 
   echo '\n'
   wv_free(sanityM.buffer)
 
-  # reportConfig("Sequential", 1, datasetSize, batchSize, imageLabels, textVocabulary)
-
-  # block:
-  #   runBench(logsumexpSerial, datasetSize, batchSize, imageLabels)
+  reportConfig("Sequential", 1, datasetSize, batchSize, imageLabels, textVocabulary)
+  block:
+    runBench(logsumexpSerial, datasetSize, batchSize, imageLabels)
   # block:
   #   runBench(logsumexpSerial, datasetSize, batchSize, textVocabulary)
 

--- a/weave/await_fsm.nim
+++ b/weave/await_fsm.nim
@@ -147,6 +147,10 @@ behavior(awaitFSA):
   transition:
     ascertain: not task.fn.isNil
     debug: log("Worker %2d: forcefut 3 - stoled tasks\n", myID())
+    TargetLastVictim:
+      if task.victim != Not_a_worker:
+        myThefts().lastVictim = task.victim
+        ascertain: myThefts().lastVictim != myID()
 
     if not task.next.isNil:
       profile(enq_deq_task):

--- a/weave/config.nim
+++ b/weave/config.nim
@@ -65,22 +65,29 @@ const WV_Backoff* {.booldefine.} = true
   ## steal requests queues when they sleep and there is latency to wake up.
 
 type
-  StealKind* {.pure.}= enum
+  StealKind* {.pure.} = enum
     one
     half
     adaptative
 
-  SplitKind* {.pure.}= enum
+  SplitKind* {.pure.} = enum
     half
     guided
     adaptative
 
+  VictimSelection* = enum
+    Random     # Always target a new victim randomly
+    LastVictim # Target the last victim if possible
+    LastThief  # Target the last thief if possible
+
 const
   WV_Steal{.strdefine.} = "adaptative"
   WV_Split{.strdefine.} = "adaptative"
+  WV_Target{.strdefine.} = "Random"
 
   StealStrategy* = parseEnum[StealKind](WV_Steal)
   SplitStrategy* = parseEnum[SplitKind](WV_Split)
+  FirstVictim* = parseEnum[VictimSelection](WV_Target)
 
 # Static scopes
 # ----------------------------------------------------------------------------------
@@ -111,6 +118,14 @@ template EagerFV*(body: untyped): untyped =
 
 template Backoff*(body: untyped): untyped =
   when WV_Backoff:
+    body
+
+template TargetLastVictim*(body: untyped): untyped =
+  when FirstVictim == LastVictim:
+    body
+
+template TargetLastThief*(body: untyped): untyped =
+  when FirstVictim == LastThief:
     body
 
 # Dynamic defines

--- a/weave/config.nim
+++ b/weave/config.nim
@@ -83,7 +83,7 @@ type
 const
   WV_Steal{.strdefine.} = "adaptative"
   WV_Split{.strdefine.} = "adaptative"
-  WV_Target{.strdefine.} = "Random"
+  WV_Target{.strdefine.} = "LastVictim"
 
   StealStrategy* = parseEnum[StealKind](WV_Steal)
   SplitStrategy* = parseEnum[SplitKind](WV_Split)

--- a/weave/datatypes/context_thread_local.nim
+++ b/weave/datatypes/context_thread_local.nim
@@ -56,11 +56,11 @@ type
     # Before a worker can become quiescent it has to drop MaxSteal - 1
     # steal request and send the remaining one to its parent
     dropped*: int32
-    # RRNG state to choose victims
+    # RNG state to choose victims
     rng*: RngState
-    when defined(StealLastVictim):
+    when FirstVictim == LastVictim:
       lastVictim*: WorkerID
-    when defined(StealLastThief):
+    when FirstVictim == LastThief:
       lastThief*: WorkerID
     # Adaptative theft
     stealHalf*: bool

--- a/weave/datatypes/sync_types.nim
+++ b/weave/datatypes/sync_types.nim
@@ -39,10 +39,12 @@ type
     stop*: int
     stride*: int
     # 64 bytes
-    futures*: pointer  # LinkedList of futures required by the current task
+    when FirstVictim == LastVictim:
+      victim*: WorkerID
     isLoop*: bool
     hasFuture*: bool   # If a task is associated with a future, the future is stored at data[0]
     futureSize*: uint8 # Size of the future result type if relevant
+    futures*: pointer  # LinkedList of futures required by the current task
     # 79 bytes
     # User data - including the FlowVar channel to send back result.
     # It is very likely that User data contains a pointer (the Flowvar channel)

--- a/weave/runtime_fsm.nim
+++ b/weave/runtime_fsm.nim
@@ -160,6 +160,10 @@ behavior(syncFSA):
     # 3. We stole some task(s)
     debug: log("Worker %2d: globalsync 3 - stoled tasks\n", myID())
     ascertain: not task.fn.isNil
+    TargetLastVictim:
+      if task.victim != Not_a_worker:
+        myThefts().lastVictim = task.victim
+        ascertain: myThefts().lastVictim != myID()
 
     if not task.next.isNil:
       profile(enq_deq_task):

--- a/weave/scheduler.nim
+++ b/weave/scheduler.nim
@@ -101,6 +101,10 @@ proc init*(ctx: var TLContext) {.gcsafe.} =
     localCtx.stealCache.access(i).victims.allocate(capacity = workforce())
 
   myThefts().rng.seed(myID())
+  TargetLastVictim:
+    myThefts().lastVictim = Not_a_worker
+  TargetLastThief:
+    myThefts().lastThief = Not_a_worker
 
   # Debug
   # -----------------------------------------------------------

--- a/weave/scheduler.nim
+++ b/weave/scheduler.nim
@@ -198,6 +198,10 @@ proc schedulingLoop() =
     # 3. We stole some task(s)
     ascertain: not task.fn.isNil
     debug: log("Worker %2d: schedloop 3 - stoled tasks\n", myID())
+    TargetLastVictim:
+      if task.victim != Not_a_worker:
+        myThefts().lastVictim = task.victim
+        ascertain: myThefts().lastVictim != myID()
 
     if not task.next.isNil:
       # Add everything

--- a/weave/signals.nim
+++ b/weave/signals.nim
@@ -32,7 +32,8 @@ proc asyncSignal(fn: proc (_: pointer) {.nimcall, gcsafe.}, chan: var ChannelSps
   profile(send_recv_task):
     let dummy = newTaskFromCache()
     dummy.fn = fn
-    # TODO: StealLastVictim
+    TargetLastVictim:
+      dummy.victim = Not_a_worker
 
     let signalSent = chan.trySend(dummy)
     debugTermination: log("Worker %2d: sending asyncSignal\n", myID())

--- a/weave/targets.nim
+++ b/weave/targets.nim
@@ -58,7 +58,18 @@ proc findVictim*(req: var StealRequest): WorkerID =
       markIdle(req.victims, myWorker().right)
 
     ascertain: myID() notin req.victims
-    result = randomVictim(req.victims, req.thiefID)
+    when FirstVictim == LastVictim:
+      if myThefts().lastVictim != Not_a_worker and myThefts().lastVictim in req.victims:
+        result = myThefts().lastVictim
+      else:
+        result = randomVictim(req.victims, req.thiefID)
+    elif FirstVictim == LastThief:
+      if myThefts().lastThief != Not_a_worker and myThefts().lastThief in req.victims:
+        result = myThefts().lastThief
+      else:
+        result = randomVictim(req.victims, req.thiefID)
+    else:
+      result = randomVictim(req.victims, req.thiefID)
 
   if result == Not_a_worker:
     # Couldn't find a victim. Return the steal request to the thief

--- a/weave/thieves.nim
+++ b/weave/thieves.nim
@@ -133,8 +133,6 @@ proc trySteal*(isOutOfTasks: bool) =
         req.state = Stealing
       else:
         req.state = Working
-
-      # TODO LastVictim/LastThief
       req.findVictimAndSteal()
 
 proc forget*(req: sink StealRequest) {.gcsafe.} =

--- a/weave/victims.nim
+++ b/weave/victims.nim
@@ -182,7 +182,8 @@ proc dispatchElseDecline*(req: sink StealRequest) {.gcsafe.}=
     ascertain: not task.fn.isNil
     ascertain: cast[ByteAddress](task.fn) != 0xFACADE
     profile(send_recv_task):
-      # TODO LastVictim
+      TargetLastVictim:
+        task.victim = myID()
       LazyFV:
         batchConvertLazyFlowvar(task)
       debug: log("Worker %2d: preparing %d task(s) for worker %2d with function address 0x%.08x\n",
@@ -201,6 +202,8 @@ proc splitAndSend*(task: Task, req: sink StealRequest) =
 
     # Copy the current task
     upperSplit[] = task[]
+    TargetLastVictim:
+      upperSplit.victim = myID()
 
     # Split iteration range according to given strategy
     # [start, stop) => [start, split) + [split, end)

--- a/weave/victims.nim
+++ b/weave/victims.nim
@@ -159,6 +159,8 @@ proc send(req: sink StealRequest, task: sink Task, numStolen: int32 = 1) {.inlin
   debug: log("Worker %2d: sending %d tasks (task.fn 0x%.08x) to Worker %2d\n",
     myID(), numStolen, task.fn, req.thiefID, req.thiefAddr)
   let taskSent = req.thiefAddr[].trySend(task)
+  TargetLastThief:
+    myThefts().lastThief = req.thiefID
 
   postCondition: taskSent # SPSC channel with only 1 slot
 


### PR DESCRIPTION
This adds the LastThief and LastVictim steal policies.

LastVictim in particular is optimal for long-running tasks over 35 microseconds.

## Analysis from A.Prell thesis:
https://epub.uni-bayreuth.de/2990

![image](https://user-images.githubusercontent.com/22738317/71533665-5dde3480-28fa-11ea-948e-2429706d160a.png)
![image](https://user-images.githubusercontent.com/22738317/71533681-74848b80-28fa-11ea-9e5a-df93fcf623de.png)
![image](https://user-images.githubusercontent.com/22738317/71533682-8108e400-28fa-11ea-854b-908a90382476.png)
![image](https://user-images.githubusercontent.com/22738317/71533698-92ea8700-28fa-11ea-8a7a-3aecef60c83a.png)

## Summary
![image](https://user-images.githubusercontent.com/22738317/71533721-c0373500-28fa-11ea-97f9-25d582e58271.png)

## In Weave's case

Compared to the orginal code, Weave fine-grained parallelism has been tremendously improved thanks to the custom memory pool (#24). Furthermore, unlike in the thesis, Weave MPSC channels are lockless and very fast for producers as they only require an exchange (and not a compare exchange). In the thesis it is mentioned that both are equivalent in terms of total messages sent probability if sending task (SPSC channel) and sending steal request (MPSC channel) have the same cost with last victim achieving greater efficiency (much more likely to steal successfully on the first try).

Due to the:
- lockless MPSC channels in Weave vs lock-based channels in the thesis
- the already exceptional performance of Weave on very fine-grained tasks
- the time spent looking for tasks on coarse-grained tasks (GEMM BLAS and probably also the pathological reductions from #35)

It probably makes more sense to have LastVictim as the default.

## In practice
Concretely this improves GEMM by 15% reaching 2.3 TFlops from 1.9TFlops on my machine
```
$  ./build/weave_gemm 

Backend:                        Weave (Pure Nim)
Type:                           float32
A matrix shape:                 (M: 1920, N: 1920)
B matrix shape:                 (M: 1920, N: 1920)
Output shape:                   (M: 1920, N: 1920)
Required number of operations: 14155.776 millions
Required bytes:                   29.491 MB
Arithmetic intensity:            480.000 FLOP/byte
Theoretical peak single-core:    224.000 GFLOP/s
Theoretical peak multi:         4032.000 GFLOP/s

Weave implementation
Collected 300 samples in 2258 ms
Average time: 6.303 ms
Stddev  time: 2.159 ms
Min     time: 6.000 ms
Max     time: 41.000 ms
Perf:         2245.760 GFLOP/s
```