### PR TITLE
Nested data parallelism experiments

### DIFF
--- a/weave/contexts.nim
+++ b/weave/contexts.nim
@@ -171,7 +171,8 @@ proc workerMetrics*() =
     c_printf("Worker %2d: %u steal requests declined\n", myID(), localCtx.counters.stealDeclined)
     c_printf("Worker %2d: %u tasks executed\n", myID(), localCtx.counters.tasksExec)
     c_printf("Worker %2d: %u tasks sent\n", myID(), localCtx.counters.tasksSent)
-    c_printf("Worker %2d: %u tasks split\n", myID(), localCtx.counters.tasksSplit)
+    c_printf("Worker %2d: %u loops split\n", myID(), localCtx.counters.loopsSplit)
+    c_printf("Worker %2d: %u loops iterations executed\n", myID(), localCtx.counters.loopsIterExec)
     StealAdaptative:
       ascertain: localCtx.counters.stealOne + localCtx.counters.stealHalf == localCtx.counters.stealSent
       if localCtx.counters.stealSent != 0:

--- a/weave/datatypes/context_thread_local.nim
+++ b/weave/datatypes/context_thread_local.nim
@@ -82,7 +82,8 @@ type
   Counters* = object
     tasksExec*: int
     tasksSent*: int
-    tasksSplit*: int
+    loopsSplit*: int
+    loopsIterExec*: int
     stealSent*: int
     stealHandled*: int
     stealDeclined*: int

--- a/weave/victims.nim
+++ b/weave/victims.nim
@@ -276,7 +276,7 @@ proc splitAndSend*(task: Task, req: sink StealRequest, workSharing: bool) =
 
     req.send(upperSplit)
 
-  incCounter(tasksSplit)
+  incCounter(loopsSplit)
   debug:
     let steps = (task.stop-task.cur + task.stride-1) div task.stride
     log("Worker %2d: Continuing with [%ld, %ld) (%d steps)\n", myID(), task.cur, task.stop, steps)


### PR DESCRIPTION
Experiments for one last push in matrix multiplication throughput.

A couple of areas were explored:
1. (inconclusive) in `schedule(Task)` if the current task is splittable that means that it just created a task and so it's a loop that generates task and it should be valuable to split it.
Unfortunately when encountering a for loop that generates task, Weave will quickly create many tasks so what will probably happen is that a loop that generate tasks is likely light in actual compute so sending the generated tasks directly is the same as sending a loop iteration.
2. (drop perf) Inverting the order of splitting the current task and sending a task from the deque. The issue with that strategy is that unless in `schedule(Task)` in other proc like shareWork/handleThieves (which call distributeWork) there is no way to know the current loop task nesting level an outer loop would be beneficial to split but not an inner one. Tracking this also seems non-trivial.
3. (slight perf increase) The current PR counts loop tasks as 1 for the purpose of adaptative stealing instead of their step count. Previously the presence of large loops iterations even if they were short to execute just shat down adaptative stealing. Tying back to experiment 1, that allows a worker to steal half of the generated tasks instead of a likely-done generated-loop.

Obligatory perf paste ~(without Backoff, Backoff Latency is an issue but can be tackled with initial spin loops).~ _or not, it is complex because a parent looks into backed off worker queues and just recirculating steal requests without cause is bad. See also https://web.njit.edu/~dingxn/papers/BWS.pdf which argues for sleeping instead of yielding (providing the OS kernel supports a "work-stealing sleep" that only reschedule the timeshare within the application)._

```
$  build/weave_gemm_experiments_3 

Backend:                        Weave (Pure Nim)
Type:                           float32
A matrix shape:                 (M: 1920, N: 1920)
B matrix shape:                 (M: 1920, N: 1920)
Output shape:                   (M: 1920, N: 1920)
Required number of operations: 14155.776 millions
Required bytes:                   29.491 MB
Arithmetic intensity:            480.000 FLOP/byte
Theoretical peak single-core:    224.000 GFLOP/s
Theoretical peak multi:         4032.000 GFLOP/s

Weave implementation
Collected 300 samples in 1977 ms
Average time: 5.210 ms
Stddev  time: 0.572 ms
Min     time: 5.000 ms
Max     time: 10.000 ms
Perf:         2717.040 GFLOP/s
```