### PR TITLE
[WIP] Dataflow graph parallelism

### DIFF
--- a/weave/channels/loop_promises_notifiers.md
+++ b/weave/channels/loop_promises_notifiers.md
@@ -138,7 +138,7 @@ proc ready*(pr: ProducersRangePromises, index: int32) =
 
   while idx != 0:
     pr.fulfilled[idx] += 1
-    idx = idx shr 1
+    idx = (idx-1) shr 1
 
   pr.fulfilled[0] += 1
 
@@ -165,7 +165,7 @@ proc dispatch*(cr: var ConsumerRangeDelayedTasks, internalIndex: int32) =
 
   while idx != 0:
     cr.dispatched[idx] += 1
-    idx = idx shr 1
+    idx = (idx-1) shr 1
 
   cr.dispatched[0] += 1
 

--- a/weave/channels/loop_promises_notifiers.md
+++ b/weave/channels/loop_promises_notifiers.md
@@ -1,0 +1,239 @@
+## Loop promises notifiers
+
+To support dataflow parallelism (delay tasks until their data dependencies are ready)
+you need a way for the producer to notify the consumers.
+For simple task this is easy, you only need a broadcast SPMC queue.
+Since those are write-once, you don't even need to deque the data
+
+However if the task is a for-loop with for example 100 iterations,
+some consumers might be waiting on index 50, some on index 15, ...
+We now have the following concerns:
+
+## Producers
+
+- The producers of a loop range are non-deterministic due to work-stealing.
+- The order of production is non-deterministic as well.
+- There is only one producer per elementary chunk.
+- Producers only need to write that their chunk is ready.
+
+## Consumers
+
+- Consumers may wait for different subsets of the whole loop
+- Consumers may wait for the whole loop, but start scheduling when a subset is ready
+- If we have a parallelFor loop that enqueues a loop task
+  then a parallelFor loop that depends on it, all the dependent tasks will
+  be held by the worker which encountered that.
+- They want to schedule as many dependent tasks as possible in a single pass
+  to maintain the busy-leaves property i.e. if as long as there is work, workers are active
+  a greedy scheduler (a scheduler that maintains the busy-leaves property) is at most
+  2x slower than the theoretical optimal schedule.
+
+## Cost-analysis
+
+### Producers
+
+Producers' cost is n * update-cost distributed on all producers.
+I.e. if the producer data structure is an array it's O(n / P), if it's a tree it's O(n log(n) / P).
+
+### Consumers
+
+- If the producers data structure is a sequence/array, the consumer can access any element in O(1) time
+  however blindly scanning for a ready task is O(n). In that case, the best strategy is for consumer
+  to start from their pending dependent tasks and check if they are ready. If we want to check all tasks
+  to schedule as many as possible this is O(n) independent of the number of actually dispatchable tasks (it could be 0 or
+  n). Then the cost is O(M * n) with M a factor dependent on how often a worker checks its potentially ready tasks.
+
+- Alternatively if the producers data-structure is a binary tree, the consumer can access any element in O(log(n))
+  time. Checking if any task is available can be made O(1)
+  so the O(log(n)) cost is only paid when it will be useful and once per possible tasks so 0(n log(n)) producer tree accesses total.
+  In that case, consumer should have a mirror tree with "dispatched" dependent tasks.
+  If we can dispatch k tasks at one time the cost is O(k log(N)), the cost is only paid when useful.
+  We also have O(n log(n)) consumer tree accesses in total.
+  The cumulated consumer cost is O(2n log(n)), this is true indepently of how often a consumer checks its ready tasks.
+
+In both cases the space cost is O(n)
+
+### Optimization
+
+Due to the bounded worst-case performance of the binary-tree solution, I lean toward that.
+However, what if all the dependent tasks or a large contiguous proportion (half) are ready?
+It seems like a waste to back to the root of the tree every time
+I sense there is an optimization to be done
+
+## Implementation
+
+The following is a thread-local implementation of the binary tree solution.
+Assume that in the runtime, for producers we will have a ptr object with atomic reference count instead of a ref object
+and the "fulfilled" field will be a seq of atomics.
+
+```Nim
+# Weave
+# Copyright (c) 2019 Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import sequtils
+
+# Producers' side
+# ----------------------------------------------------
+
+# Note, for this example, the producer and consumer are on the same thread
+# In the actual implementation, "ProducersRangePromises"
+# must be atomicRefCounted and the items in fulfilled must be atomic as well.
+
+type
+  ProducersRangePromises = ref object
+    ## This is a "distributed" binary indexed tree
+    ## that holds promises over a for-loop range.
+    ## The producers which fulfill a promise updates this tree.
+    # In the threaded-case, this is easily thread-safe as only monotonic increment are used
+    # The main issue is false-sharing / cache-ping pong if many thread are fulfilling
+    # promises stored in the same cache lin, but padding would be very memory inefficient.
+    start, stop, stride: int32
+    fullfilled: seq[int32]
+
+proc newPromiseRange(start, stop, stride: int32): ProducersRangePromises =
+  assert stop > start
+  assert stride > 0
+
+  new result
+  result.start = start
+  result.stop = stop
+  result.stride = stride
+
+  let bufLen = (result.stop - result.start + result.stride-1) div result.stride
+  result.fullfilled.newSeq(bufLen)
+
+proc getInternalIndex(pr: ProducersRangePromises, iterIndex: int32): int32 {.inline.} =
+  assert iterIndex in pr.start ..< pr.stop
+  result = (iterIndex - pr.start) div pr.stride
+
+proc len(pr: ProducersRangePromises): int32 {.inline.} =
+  pr.fullfilled.len.int32
+
+proc ready*(pr: ProducersRangePromises, index: int32) =
+  ## requires the public iteration index in [start, stop) range.
+  assert index in pr.start ..< pr.stop
+  var idx = pr.getInternalIndex(index)
+  while true:
+    pr.fullfilled[idx] += 1
+    idx = idx shr 1
+    if idx == 0:
+      break
+
+# Consumers' side
+# ----------------------------------------------------
+
+type
+  ConsumerRangeDelayedTasks = object
+    ## A Range-delayed task is a task that is dependent on a loop range.
+    ## The consumer will schedule those tasks piece by piece as they become available.
+    ## The consumer keeps track of tasks already dispatched and the ready tasks published by the producer.
+    ## This is thread-local. Many consumer can depend on the same producers' promises.
+    ## The last one should release ProducersPromises memory.
+    promises: ProducersRangePromises
+    dispatched: seq[int32]
+
+proc newConsumerRangeDelayedTasks(pr: ProducersRangePromises): ConsumerRangeDelayedTasks =
+  result.promises = pr
+  result.dispatched.newSeq(pr.fullfilled.len)
+
+proc dispatch*(cr: var ConsumerRangeDelayedTasks, internalIndex: int32) =
+  ## requires the internal index in [0, dispatched.len) range.
+  var idx = internalIndex
+  while true:
+    cr.dispatched[idx] += 1
+    idx = idx shr 1
+    if idx == 0:
+      break
+
+proc anyAvailable(cr: ConsumerRangeDelayedTasks, index: int32): bool {.inline.} =
+  let pr = cr.promises
+  if index >= pr.len:
+    return false
+  return pr.fullfilled[index] > cr.dispatched[index]
+
+proc anyFulfilled*(cr: var ConsumerRangeDelayedTasks): tuple[foundNew: bool, index: int32] =
+  ## This search for a fulfilled promise that wasn't already
+  ## dispatched.
+  ## If it finds one, it will be marked dispatched and its internal index will be returned.
+  while true:
+    # 3 cases (non-exclusive)
+    #   1. there is an availability in the left subtree
+    #   2. there is an availability in the right subtree
+    #   3. the current node is available
+    let left = 2*result.index + 1
+    let right = left + 1
+    if cr.anyAvailable(left):
+      result.index = left
+    elif cr.anyAvailable(right):
+      result.index = right
+    elif cr.anyAvailable(result.index):
+      # The current node is available and none of the children are
+      break
+    else:
+      assert result.foundNew == false
+      return
+
+  # We found an available node, update the dispatch tree
+  result.foundNew = true
+  assert result.index in 0 ..< cr.dispatched.len
+  cr.dispatch(result.index)
+
+when isMainModule:
+  # block:
+  #   let pr = newPromiseRange(32, 128, 32)
+  #   for i in 32'i32..< 128:
+  #     echo "i: ", i, ", internalIndex: ", pr.getInternalIndex(i)
+
+  block:
+    let pr = newPromiseRange(0, 10, 1)
+    var cr = newConsumerRangeDelayedTasks(pr)
+    echo pr[]
+
+    echo "Adding 7"
+    pr.ready(7)
+    echo pr[]
+
+    block:
+      let promise = cr.anyFulfilled()
+      echo "searching for promise: ", promise
+
+    block:
+      let promise = cr.anyFulfilled()
+      echo "searching for promise: ", promise
+
+    echo "Adding [2, 0]"
+    pr.ready(2)
+    pr.ready(0)
+
+    block:
+      let promise = cr.anyFulfilled()
+      echo "searching for promise: ", promise
+
+    echo "Adding [3, 4]"
+    pr.ready(3)
+    pr.ready(4)
+
+    block:
+      let promise = cr.anyFulfilled()
+      echo "searching for promise: ", promise
+
+    block:
+      let promise = cr.anyFulfilled()
+      echo "searching for promise: ", promise
+
+    block:
+      let promise = cr.anyFulfilled()
+      echo "searching for promise: ", promise
+
+    block:
+      let promise = cr.anyFulfilled()
+      echo "searching for promise: ", promise
+
+    block:
+      let promise = cr.anyFulfilled()
+      echo "searching for promise: ", promise
+```

--- a/weave/channels/loop_promises_notifiers.nim
+++ b/weave/channels/loop_promises_notifiers.nim
@@ -56,6 +56,8 @@ proc `=destroy`*(prom: var ProducersLoopPromises) {.inline.} =
   else:
     discard fetchSub(prom.lp.refCount, 1, moRelease)
 
+  prom.lp = nil
+
 proc `=sink`*(dst: var ProducersLoopPromises, src: ProducersLoopPromises) {.inline.} =
   # Don't pay for atomic refcounting when compiler can prove there is no ref change.
   `=destroy`(dst)

--- a/weave/channels/loop_promises_notifiers.nim
+++ b/weave/channels/loop_promises_notifiers.nim
@@ -1,0 +1,122 @@
+# Weave
+# Copyright (c) 2019 Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Stdlib
+  std/atomics,
+  # Internals
+  ../config,
+  ../memory/[allocs, memory_pools],
+  ../instrumentation/contracts
+
+# Producers' side
+# ----------------------------------------------------
+
+type
+  ProducersLoopPromises* = object
+    ## This is a concurrent binary array tree
+    ## that holds promises over a for-loop range.
+    ## The producers which fulfill a promise update this tree.
+    ## Consumers have a read-only view of it.
+    ##
+    ## It can be viewed as a collection of write-once, broadcast SPMC channels
+    # Implementation detail and design goal are explained in the companion markdown file
+    # Indirection is needed as destructors can only be defined on objects
+    lp*: ProducersLoopPromisesPtr
+
+  ProducersLoopPromisesPtr = ptr object
+
+    refCount{.align: WV_MemBlockSize.}: Atomic[int32]
+    start*, stop*, stride*: int32
+    fulfilled*: ptr UncheckedArray[Atomic[int32]]
+    numBuckets*: int32
+
+proc `=destroy`*(prom: var ProducersLoopPromises) {.inline.} =
+  let oldCount = fetchSub(prom.lp.refCount, 1, moRelease)
+  ascertain: oldCount > 0
+  ascertain: not prom.lp.fulfilled.isNil
+  if oldCount == 1:
+    fence(moAcquire)
+    # Return memory to the memory pool
+    recycle(prom.lp)
+
+proc `=`*(dst: var ProducersLoopPromises, src: ProducersLoopPromises) {.inline.}
+  # Workaround: https://github.com/nim-lang/Nim/issues/13025
+
+proc `=sink`*(dst: var ProducersLoopPromises, src: ProducersLoopPromises) {.inline.} =
+  # Don't pay for atomic refcounting when compiler can prove there is no ref change.
+  system.`=sink`(dst, src)
+
+proc `=`*(dst: var ProducersLoopPromises, src: ProducersLoopPromises) {.inline.} =
+  let oldCount = fetchAdd(src.lp.refCount, 1, moRelaxed)
+  ascertain: oldCount > 0
+  system.`=`(dst, src)
+
+proc initialize*(plp: var ProducersLoopPromises, pool: var TLPoolAllocator, start, stop, stride: int32) =
+  ## Allocate loop promises (producer side)
+  ## Multiple consumers can depend on the delivery of those promises
+  ## This is thread-safe.
+  preCondition: stop > start
+  preCondition: stride > 0
+
+  plp.lp = pool.borrow(typeof plp.lp[])
+  plp.lp.refCount.store(1, moRelaxed)
+  plp.lp.start = start
+  plp.lp.stop = stop
+  plp.lp.stride = stride
+
+  plp.lp.numBuckets = (plp.lp.stop - plp.lp.start + plp.lp.stride-1) div plp.lp.stride
+  plp.lp.fulfilled = wv_alloc(Atomic[int32], plp.lp.numBuckets)
+  zeroMem(plp.lp.fulfilled, sizeof(int32) * plp.lp.numBuckets)
+  # Do we need a caching scheme? The memory pool does not handle
+  # array allocation so we rely on the system allocator.
+
+proc getBucket*(pr: ProducersLoopPromises, index: int32): int32 {.inline.} =
+  ## Convert a possibly offset and/or strided for-loop iteration index
+  ## to a promise bucket in the range [0, num_iterations)
+  ## suitable for storing promises and task metadata in a linear array.
+  preCondition: index in pr.lp.start ..< pr.lp.stop
+  result = (index - pr.lp.start) div pr.lp.stride
+
+proc ready*(pr: ProducersLoopPromises, index: int32) =
+  ## requires the public iteration index in [start, stop) range.
+  ## Flag a loop iteration as ready.
+  # The flag is propagated to the root of the tree
+  # so that by looking at the root we can
+  # see if a new promise was delivered upon in O(1) time.
+  preCondition: index in pr.lp.start ..< pr.lp.stop
+  var idx = pr.getBucket(index)
+  ascertain: pr.lp.fulfilled[idx].load(moRelaxed) == 0
+
+  while idx != 0:
+    discard pr.lp.fulfilled[idx].fetchAdd(1, moRelaxed)
+    idx = idx shr 1
+
+  discard pr.lp.fulfilled[0].fetchAdd(1, moRelaxed)
+
+
+# Sanity checks
+# ------------------------------------------------------------------------------
+# TODO: multithreaded test case
+
+when isMainModule:
+
+  proc main() =
+    # Promises can't be globals, Nim bug: https://github.com/nim-lang/Nim/issues/13024
+    echo "Testing Loop Promises (Producer)"
+
+    var pool: TLPoolAllocator
+    pool.initialize()
+
+    block: # Fulfilling all promises
+      var prodLoopPromises: ProducersLoopPromises
+      prodLoopPromises.initialize(pool, 0, 10000, 1)
+      for i in 0'i32 ..< 10000:
+        prodLoopPromises.ready(i)
+      doAssert prodLoopPromises.lp.fulfilled[0].load(moRelaxed) == 10000
+
+  main()

--- a/weave/datatypes/promises.nim
+++ b/weave/datatypes/promises.nim
@@ -9,9 +9,10 @@ import
   # stdlib
   atomics, locks,
   # Internals
-  ../channels/[channels_spsc_single, channels_mpsc_unbounded_batch],
-  ../memory/memory_pools,
-  ../instrumentation/contracts
+  ../channels/[channels_spsc_single_ptr, loop_promises_notifiers],
+  ../memory/[allocs, memory_pools],
+  ../instrumentation/contracts,
+  ../config
 
 # Promises
 # ----------------------------------------------------
@@ -32,7 +33,17 @@ import
 type
   DummyPtr = ptr object
 
-  Promise* = ptr object
+  Promise = object
+    ## A promise is a placeholder for the input of a task.
+    ## Tasks that depend on a promise are delayed until that
+    ## promise is delivered.
+    ##
+    ## The difference with future/flowvar is that futures/flowvar
+    ## represent a delayed result while promise represent a delayed input.
+    p: PromisePtr
+
+  PromisePtr = ptr object
+    # Implementation: A promise is a write-once, broadcast SPMC channel.
     # The channel is intrusive and enforces WV_CacheLinePadding alignment
     chan{.align:WV_CacheLinePadding.}: ChannelSpscSinglePtr[DummyPtr]
     refCount: Atomic[int32]
@@ -45,82 +56,168 @@ const dummy = cast[DummyPtr](0xFACADE)
 # Internal
 # ----------------------------------------------------
 
-proc isFulfilled*(prom: Promise): bool {.inline.} =
-  ## Check if a promise is fulfilled.
-  # Library-only
-  not prom.chan.isEmpty
+proc `=destroy`*(prom: var Promise) {.inline.} =
+  let oldCount = fetchSub(prom.p.refCount, 1, moRelease)
+  if oldCount == 1:
+    fence(moAcquire)
+    # Return memory to the memory pool
+    recycle(prom.p)
+
+proc `=`*(dst: var Promise, src: Promise) {.inline.}
+  # Workaround: https://github.com/nim-lang/Nim/issues/13025
+
+proc `=sink`*(dst: var Promise, src: Promise) {.inline.} =
+  # Don't pay for atomic refcounting when compiler can prove there is no ref change
+  system.`=sink`(dst, src)
 
 proc `=`*(dst: var Promise, src: Promise) {.inline.} =
-  let oldCount = fetchAdd(src.refCount, 1, moRelaxed)
+  let oldCount = fetchAdd(src.p.refCount, 1, moRelaxed)
   ascertain: oldCount > 0
   system.`=`(dst, src)
 
-proc `=destroy`*(prom: var Promise) {.inline.} =
-  let oldCount = fetchSub(prom.refCount, 1, moRelease)
-  if oldCount == 1:
-    fetch(moAcquire)
-    # Return memory to the memory pool
-    recycle(prom)
+proc isFulfilled*(prom: Promise): bool {.inline.} =
+  ## Check if a promise is fulfilled.
+  # Library-only
+  not prom.p.chan.isEmpty
 
 # Public
 # ----------------------------------------------------
+# newPromise needs an extra wrapper that hides the pool allocator
 
 proc newPromise*(pool: var TLPoolAllocator): Promise {.inline.} =
   ## Create a new promise.
   ## Promise allows to express fine-grain task dependencies
   ## Task dependent on promises will be delayed until it is fulfilled.
-  pool.borrow(typeof result[])
-  result.refCount.store(1, moRelaxed)
+  result.p = pool.borrow(typeof result.p[])
+  result.p.refCount.store(1, moRelaxed)
 
-proc fulfill*(prom: Promise) {.inline.}:
+proc fulfill*(prom: Promise) {.inline.} =
   ## Deliver on a Promise
   ## Tasks dependent on this promise can now be scheduled.
-  preCondition: not prom.isNil
-  preCondition: prom.isEmpty
-  let wasDelivered = chan.trySend(dummy)
+  preCondition: not prom.p.isNil
+  preCondition: prom.p.chan.isEmpty
+  let wasDelivered = prom.p.chan.trySend(dummy)
   postCondition: wasDelivered
 
 # Promise ranges
 # ----------------------------------------------------
 # A promise range is a generalization of promises
 # to support a for-loop range
-# It is necessary to use loop tiling to process
-# large loops with dependencies (i.e. depends on tile [0, 32), [32, 64), ...)
 
 type
-  PackedPromises = object
-    # A pack of 256 promises (WV_MemBlockSize) that
-    # fit in a memory pool block.
-    proms: array[WV_MemBlockSize, bool]
+  ConsumerLoopPromises* = object
+    ## A "consumer loop promises" object tracks the difference
+    ## between what iterations of a for-loop are ready
+    ## and what delayed tasks have yet to be scheduled
+    # This is thread-local but keeps a reference
+    # to the thread-safe producers broadcasting channels
+    producers: ProducersLoopPromises
+    dispatched: ptr UncheckedArray[int32]
 
-  PromiseRange* = ptr object
-    ## A promise range allows expressing dependencies over a for-loop.
-    ## A PromiseRange can at most express up to 7168 iteration dependencies
-    ##
-    ## For example you can express dependencies for
-    ##
-    ## parallelFor 0 ..< 7168:
-    ##   ...
-    ##
-    ## or
-    ##
-    ## parallelFor 0 ..< 458752, stride = 64:
-    ##   ...
-    ##
-    ## Use tiling to express dependencies on large loop ranges:
-    ##
-    ## const tileSize = 64
-    ## parallelForStrided i in 0 ..< M, stride = tileSize:
-    ##   for ii in i ..< min(i+tileSize, M):
-    ##     ...
-    ##
-    ## Tiling significantly improve cache usage and compute locality
-    ## also significantly diminishes scheduling overhead.
+proc newConsumerLoopPromises*(producers: ProducersLoopPromises): ConsumerLoopPromises =
+  ## Create a new thread-local consumer of loop promises
+  result.producers = producers
+  result.dispatched = wv_alloc(int32, producers.lp.numBuckets)
+  zeroMem(result.dispatched, sizeof(int32) * producers.lp.numBuckets)
 
-    # TODO: this is using shared-memory in a message-passing based runtime!
-    # Max promises on 64-bit: (256 - 4*32) div 8 * 256 = 7168
-    refCount: Atomic[int32]
-    start: int
-    stop: int   # Non-inclusive stop
-    stride: int
-    promises: array[(WV_MemBlockSize - 4*sizeof(int)) div sizeof(pointer), ptr PackedPromises]
+proc dispatch(clp: ConsumerLoopPromises, bucket: int32) =
+  ## Flag a task bucket as dispatched.
+  var idx = bucket
+  while idx != 0:
+    clp.dispatched[idx] += 1
+    idx = idx shr 1
+
+  clp.dispatched[0] += 1
+
+proc anyAvailable(clp: ConsumerLoopPromises, bucket: int32): bool {.inline.} =
+  if bucket >= clp.producers.lp.numBuckets:
+    return false
+  let dispatched = clp.dispatched[bucket]
+  let available = clp.producers.lp.fulfilled[bucket].load(moRelaxed)
+  # fence(moAcquire) - TODO: I'm pretty sure this is not needed even on weak memory models.
+  return available > dispatched
+
+proc anyFulfilled*(clp: ConsumerLoopPromises): tuple[foundNew: bool, bucket: int32] =
+  ## Searches for a fulfilled promise that wasn't already dispatchindexed.
+  ## If one is found, it will be marked dispatched and its bucket will be returned.
+  if not clp.anyAvailable(bucket = 0):
+    return
+
+  while true:
+    # 3 cases (non-exclusive)
+    #   1. there is an availability in the left subtree
+    #   2. there is an availability in the right subtree
+    #   3. the current node is available
+    let left = 2*result.bucket + 1
+    let right = left + 1
+    if clp.anyAvailable(left):
+      result.bucket = left
+    elif clp.anyAvailable(right):
+      result.bucket = right
+    else: # The current node is available and none of the children are
+      break
+
+  # We found an available node, update the dispatch tree
+  result.foundNew = true
+  ascertain: result.bucket in 0 ..< clp.producers.lp.numBuckets
+  clp.dispatch(result.bucket)
+
+# Sanity checks
+# ------------------------------------------------------------------------------
+# TODO: multithreaded test cases, at least for correct destructors/memory reclamation
+#       since SPMC broadcast channels can be tested with a single thread-local consumer.
+
+when isMainModule:
+
+  proc main() =
+    # Promises can't be globals, Nim bug: https://github.com/nim-lang/Nim/issues/13024
+    echo "Testing Loop promises (producer + Consumer)"
+
+    var pool: TLPoolAllocator
+    pool.initialize()
+
+    var plp: ProducersLoopPromises
+    plp.initialize(pool, 0, 10, 1)
+    var clp = newConsumerLoopPromises(plp)
+
+    block:
+      let promise = clp.anyFulfilled()
+      doAssert not promise.foundNew
+
+    plp.ready(7)
+
+    block:
+      let promise = clp.anyFulfilled()
+      doAssert promise.foundNew and promise.bucket == 7
+
+    block:
+      let promise = clp.anyFulfilled()
+      doAssert not promise.foundNew
+
+    plp.ready(2)
+    plp.ready(0)
+
+    block:
+      let promise = clp.anyFulfilled()
+      doAssert promise.foundNew and promise.bucket == 2
+
+    plp.ready(3)
+    plp.ready(4)
+
+    block:
+      let promise = clp.anyFulfilled()
+      doAssert promise.foundNew and promise.bucket == 3
+
+    block:
+      let promise = clp.anyFulfilled()
+      doAssert promise.foundNew and promise.bucket == 4
+
+    block:
+      let promise = clp.anyFulfilled()
+      doAssert promise.foundNew and promise.bucket == 0
+
+    block:
+      let promise = clp.anyFulfilled()
+      doAssert not promise.foundNew
+
+  main()

--- a/weave/datatypes/promises.nim
+++ b/weave/datatypes/promises.nim
@@ -1,0 +1,81 @@
+# Weave
+# Copyright (c) 2019 Mamy André-Ratsimbazafy
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # stdlib
+  atomics, locks,
+  # Internals
+  ../channels/[channels_spsc_single, channels_mpsc_unbounded_batch],
+  ../memory/memory_pools,
+  ../instrumentation/contracts
+
+# Promises
+# ----------------------------------------------------
+# Promises are the counterpart to Flowvar.
+#
+# When a task depends on a promise, it is delayed until the promise is fulfilled
+# This allows to model precise dependencies between tasks
+# beyond what traditional control-flow dependencies (function calls, barriers, locks) allow.
+#
+# Furthermore control-flow dependencies like barriers and locks suffer from:
+# - composability problem (barriers are incompatible with work stealing or nested parallelism).
+# - restrict the parallelism exposed.
+# - expose the programmers to concurrency woes that could be avoided
+#   by specifying precede/after relationship
+#
+# Details, use-cases, competing approaches provided at: https://github.com/mratsim/weave/issues/31
+
+type
+  DummyPtr = ptr object
+
+  Promise* = ptr object
+    # The channel is intrusive and enforces WV_CacheLinePadding alignment
+    chan{.align:WV_CacheLinePadding.}: ChannelSpscSinglePtr[DummyPtr]
+    refCount: Atomic[int32]
+
+const dummy = cast[DummyPtr](0xFACADE)
+
+# TODO: do we need extra caching beyond the memory pool
+#       like the lookaside list?
+
+# Internal
+# ----------------------------------------------------
+
+proc isFulfilled*(prom: Promise): bool {.inline.} =
+  ## Check if a promise is fulfilled.
+  # Library-only
+  not prom.chan.isEmpty
+
+proc `=`*(dst: var Promise, src: Promise) {.inline.} =
+  let oldCount = fetchAdd(src.refCount, 1, moRelaxed)
+  ascertain: oldCount > 0
+  system.`=`(dst, src)
+
+proc `=destroy`*(prom: var Promise) {.inline.} =
+  let oldCount = fetchSub(prom.refCount, 1, moRelease)
+  if oldCount == 1:
+    fetch(moAcquire)
+    # Return memory to the memory pool
+    recycle(prom)
+
+# Public
+# ----------------------------------------------------
+
+proc newPromise*(pool: var TLPoolAllocator): Promise {.inline.} =
+  ## Create a new promise.
+  ## Promise allows to express fine-grain task dependencies
+  ## Task dependent on promises will be delayed until it is fulfilled.
+  pool.borrow(typeof result[])
+  result.refCount.store(1, moRelaxed)
+
+proc fulfill*(prom: Promise) {.inline.}:
+  ## Deliver on a Promise
+  ## Tasks dependent on this promise can now be scheduled.
+  preCondition: not prom.isNil
+  preCondition: prom.isEmpty
+  let wasDelivered = chan.trySend(dummy)
+  postCondition: wasDelivered

--- a/weave/instrumentation/profilers.nim
+++ b/weave/instrumentation/profilers.nim
@@ -24,7 +24,7 @@ const
 
 template checkName(name: untyped) {.used.} =
   static:
-    if astToStr(name) notin ["run_task", "enq_deq_task", "send_recv_task", "send_recv_req", "idle"]:
+    if astToStr(name) notin ["run_task", "enq_deq_task", "enq_deq_delayed_task", "send_recv_task", "send_recv_req", "idle"]:
       raise newException(
         ValueError,
         "Invalid profile name: \"" & astToStr(name) & "\"\n" &
@@ -81,12 +81,14 @@ when defined(WV_Profile):
       timer_elapsed(timer_send_recv_req, tkMicroseconds),
       timer_elapsed(timer_send_recv_task, tkMicroseconds),
       timer_elapsed(timer_enq_deq_task, tkMicroseconds),
+      timer_elapsed(timer_enq_deq_delayed_task, tkMicroseconds),
       timer_elapsed(timer_idle, tkMicroseconds),
       timers_elapsed(
         timer_run_task,
         timer_send_recv_req,
         timer_send_recv_task,
         timer_enq_deq_task,
+        timer_enq_deq_delayed_task,
         timer_idle,
         tkMicroseconds
       )

--- a/weave/memory/memory_pools.nim
+++ b/weave/memory/memory_pools.nim
@@ -527,6 +527,8 @@ proc recycle*[T](p: ptr T) {.gcsafe.} =
   # Find the owning arena
   let arena = p.getArena()
 
+  # TODO: optional double-frees detection
+
   if getMemThreadID() == arena.meta.threadID.load(moRelaxed):
     # thread-local free
     if arena.meta.localFree.isNil:

--- a/weave/memory/memory_pools.nim
+++ b/weave/memory/memory_pools.nim
@@ -82,6 +82,7 @@ const SizeofMetadata: int = (block:
   ## update this const
 
 const MaxBlocks = (WV_MemArenaSize - SizeofMetadata) div WV_MemBlockSize
+  ## 62
 
 type
   MemBlock {.union.} = object


### PR DESCRIPTION
Heavy work-in-progress, ideas welcome.

This is research work on implementing data flow parallelism (also called stream parallelism, pipeline parallelism, data-driven task parallelism).

Needs, research, other runtime approaches are detailed starting from the following comment: https://github.com/mratsim/weave/issues/31#issuecomment-569850126.

The practical direct goal is to be able to call Weave Matrix Multiplication from a parallel loop as in many cases we might have a batch of small matrices, say 64 images of size 224x224 (the base image size in ImageNet dataset) and it would be more efficient to find parallelism at the batch level instead of intra-level. This is currently impossible in Weave (or OpenMP for that matter).

The reason why is that the current implementation requires a barrier after the outer parallel for that represents data dependencies:
https://github.com/mratsim/weave/blob/5d9017239ca9792cc37e3995f422f86ac57043ab/benchmarks/matmul_gemm_blas/gemm_pure_nim/gemm_weave.nim#L166-L182
But that barrier can only be called from the root task/main thread preventing nesting in another extra parallel region.
Furthermore, precise barriers are fundamentally incompatible with work-stealing because there is no way to know which threads may execute a code path so some may never hit the barrier and we will be deadlocked.

Instead we can properly tell the runtime the actual dependencies: what data is needed to continue computation.

Note that this is pretty much uncharted territory at the moment and I'm already worried about the overhead and it will require several refinements.