### PR TITLE
Reduce mpsc padding

### DIFF
--- a/weave/config.nim
+++ b/weave/config.nim
@@ -36,6 +36,9 @@ const WV_CacheLinePadding* {.intDefine.} = 128
   ## However, it has been shown that due to some Intel CPU prefetching
   ## 2 cache lines at once, 128 bytes was often necessary.
   ## Samsung Exynos CPU, Itanium, modern PowerPC and some MIPS uses 128 bytes.
+  ##
+  ## Note: The MPSC channel is padded by 128/2 = 64 to make memory
+  ##       fit in the memory pool blocks. Adjust The memory pool blocksize accordingly.
   # Nim threadpool uses 32 bytes :/
   # https://github.com/nim-lang/Nim/blob/v1.0.2/lib/pure/concurrency/threadpool.nim
 

--- a/weave/memory/memory_pools.nim
+++ b/weave/memory/memory_pools.nim
@@ -619,7 +619,10 @@ proc takeover*(pool: var TLPoolAllocator, target: sink TLPoolAllocator) =
 
 # Sanity checks and bench
 # ----------------------------------------------------------------------------------
-echo sizeof(ChannelMpscUnboundedBatch[ptr MemBlock])
+# TODO those checks hardcode the WV_MemBlockSize and in turn the padding
+# TODO: Once upstream fixes https://github.com/nim-lang/Nim/issues/13122
+#       the size here will likely be wrong
+
 assert sizeof(ChannelMpscUnboundedBatch[ptr MemBlock]) == 272,
   "MPSC channel size was " & $sizeof(ChannelMpscUnboundedBatch[ptr MemBlock])
 

--- a/weave/memory/memory_pools.nim
+++ b/weave/memory/memory_pools.nim
@@ -50,11 +50,11 @@ const WV_MemBlockSize* {.intdefine.} = 256
 # - LLVM Address Sanitizer and memory poisoning (https://clang.llvm.org/docs/AddressSanitizer.html)
 # - Valgrind with custom memory pool (http://valgrind.org/docs/manual/mc-manual.html#mc-manual.mempools)
 
-static: assert WV_MemArenaSize.isPowerOfTwo(), "WV_ArenaSize must be a power of 2"
-static: assert WV_MemArenaSize > 4096, "WV_ArenaSize must be greater than a OS page (4096 bytes)"
+static: doAssert WV_MemArenaSize.isPowerOfTwo(), "WV_ArenaSize must be a power of 2"
+static: doAssert WV_MemArenaSize > 4096, "WV_ArenaSize must be greater than a OS page (4096 bytes)"
 
-static: assert WV_MemBlockSize.isPowerOfTwo(), "WV_MemBlockSize must be a power of 2"
-static: assert WV_MemBlockSize >= 256, "WV_MemBlockSize must be greater or equal to 256 bytes to hold tasks and channels."
+static: doAssert WV_MemBlockSize.isPowerOfTwo(), "WV_MemBlockSize must be a power of 2"
+static: doAssert WV_MemBlockSize >= 256, "WV_MemBlockSize must be greater or equal to 256 bytes to hold tasks and channels."
 
 template debugMem*(body: untyped) =
   when defined(WV_debugMem):
@@ -619,7 +619,7 @@ proc takeover*(pool: var TLPoolAllocator, target: sink TLPoolAllocator) =
 
 # Sanity checks and bench
 # ----------------------------------------------------------------------------------
-
+echo sizeof(ChannelMpscUnboundedBatch[ptr MemBlock])
 assert sizeof(ChannelMpscUnboundedBatch[ptr MemBlock]) == 272,
   "MPSC channel size was " & $sizeof(ChannelMpscUnboundedBatch[ptr MemBlock])
 


### PR DESCRIPTION
This addresses part of #93, reducing the MPSC padding so that the data structure fits in 192 bytes leaving enough space for it to be used intrusively in memory pool allocated data structure like pledges.

Unfortunately the {.align.} pragma for generics is actually not applied so MPSC Channel is not padded.
This means that currently cache conflicts between threads are high and performance will be increased (especially on the steal requests overhead front), but it may also cause size issues in the future.

See upstream: https://github.com/nim-lang/Nim/issues/13122