### PR TITLE
also avoid UFCS for `readyWith`

### DIFF
--- a/weave/parallel_macros.nim
+++ b/weave/parallel_macros.nim
@@ -319,7 +319,7 @@ proc addLoopTask*(
           when defined(WV_profile):
             timer_stop(timer_enq_deq_task)
       else:
-        `futureIdent`.readyWith(default(`resultFutureType`.T))
+        readyWith(`futureIdent`, default(`resultFutureType`.T))
   else:
     statement.add quote do:
       if likely(`stop`-`start` != 0):

--- a/weave/parallel_reduce.nim
+++ b/weave/parallel_reduce.nim
@@ -217,7 +217,7 @@ macro parallelReduceImpl*(loopParams: untyped, stride: int, body: untyped): unty
         let offset = cast[pointer](cast[ByteAddress](param) +% sizeof(`FutTy`))
         let `env` = cast[ptr `CapturedTy`](offset)
       let res = `fnCall`
-      `fut`[].readyWith(res)
+      readyWith(`fut`[], res)
 
   # Create the task
   # --------------------------------------------------------

--- a/weave/parallel_tasks.nim
+++ b/weave/parallel_tasks.nim
@@ -154,7 +154,7 @@ proc spawnImpl(pledges: NimNode, funcCall: NimNode): NimNode =
 
         let `data` = cast[ptr `futArgsTy`](param) # TODO - restrict
         let res = `fnCall`
-        `data`[0].readyWith(res)
+        readyWith(`data`[0], res)
 
     # Create the task
     let freshIdent = ident($retType)


### PR DESCRIPTION
After your change for `isRootTask`, `readyWith` also complained.

I also changed it in `parallel_reduce` and `parallel_macros`, since I assume the problem will happen with those under the same circumstances as well.