### PR TITLE
Update mpsc padding

### DIFF
--- a/weave/channels/pledges.nim
+++ b/weave/channels/pledges.nim
@@ -167,7 +167,7 @@ type
     # The MPSC Channel is intrusive to the PledgeImpl.
     # The end fields in the channel should be the consumer
     # to avoid cache-line conflicts with producer threads.
-    chan{.align: WV_CacheLinePadding div 2.}: ChannelMpscUnboundedBatch[TaskNode]
+    chan: ChannelMpscUnboundedBatch[TaskNode]
     deferredIn: Atomic[int32]
     deferredOut: Atomic[int32]
     fulfilled: Atomic[bool]
@@ -510,13 +510,14 @@ macro delayedUntilMulti*(task: Task, pool: var TLPoolAllocator, pledges: varargs
 
 # Sanity checks
 # ------------------------------------------------------------------------------
-# TODO: Once upstream fixes https://github.com/nim-lang/Nim/issues/13122
-#       the size here will be wrong
 
-assert sizeof(ChannelMpscUnboundedBatch[TaskNode]) == 56, # Upstream {.align.} bug
+assert sizeof(default(TaskNode)[]) == 40,
+  "TaskNode size was " & $sizeof(default(TaskNode)[])
+
+assert sizeof(ChannelMpscUnboundedBatch[TaskNode]) == 128,
   "MPSC channel size was " & $sizeof(ChannelMpscUnboundedBatch[TaskNode])
 
-assert sizeof(PledgeImpl) == 128,
+assert sizeof(PledgeImpl) == 192,
   "PledgeImpl size was " & $sizeof(PledgeImpl)
 
 assert sizeof(default(PledgePtr)[]) <= WV_MemBlockSize,

--- a/weave/memory/memory_pools.nim
+++ b/weave/memory/memory_pools.nim
@@ -66,7 +66,7 @@ template debugMem*(body: untyped) =
 
 const SizeofMetadata: int = (block:
     var size: int
-    size += 384                               # ChannelMpscUnboundedBatch
+    size += 320                               # ChannelMpscUnboundedBatch
     size += sizeof(pointer)                   # localFree
     size += sizeof(pointer)                   # free
     size += sizeof(int32)                     # used
@@ -623,7 +623,7 @@ proc takeover*(pool: var TLPoolAllocator, target: sink TLPoolAllocator) =
 # TODO: Once upstream fixes https://github.com/nim-lang/Nim/issues/13122
 #       the size here will likely be wrong
 
-assert sizeof(ChannelMpscUnboundedBatch[ptr MemBlock]) == 384,
+assert sizeof(ChannelMpscUnboundedBatch[ptr MemBlock]) == 320,
   "MPSC channel size was " & $sizeof(ChannelMpscUnboundedBatch[ptr MemBlock])
 
 assert sizeof(Arena) == WV_MemArenaSize,


### PR DESCRIPTION
This updates the MPSC channel padding after the fix of https://github.com/nim-lang/Nim/issues/13122

There is a tricky compromise for the pledges data structure size:

https://github.com/mratsim/weave/blob/71cf68137bd27e9ba175b468a342a8e61a647faa/weave/channels/pledges.nim#L146-L173

The `kind` field (1 byte) has to be the first field of PledgePtr, so when the `ChannelMPSCunbounded[TaskNode]` is made intrusive, the cacheline alignment requirements automatically mades it take over 64 bytes.
Also even if the back/count/front are tagged with 64 bytes alignment each (total 192 bytes)
https://github.com/mratsim/weave/blob/71cf68137bd27e9ba175b468a342a8e61a647faa/weave/channels/channels_mpsc_unbounded_batch.nim#L50-L80

the extra deferredIn, deferredOut, fulfilled fields are not using the extra space after the `front` field:
https://github.com/mratsim/weave/blob/71cf68137bd27e9ba175b468a342a8e61a647faa/weave/channels/pledges.nim#L160-L173
probably because the data structures are distinct.

This makes it impossible to have PledgePtr[] be under 256 bytes. The 3 workarounds are:
1. Increase WV_MemBlockSize to 512 bytes
2. Don't have PledgeImpl intrusive to PledgePtr. This requires an extra allocation/pointer indirection
3. Reduce the size taken by MPSC channels

Given that before https://github.com/nim-lang/Nim/issues/13122, there was no padding and the MPSC channel could reasonably handle cache line invalidation and that in most MPSC channels implementations there is no padding at all, solution 3 is chosen in this PR