### PR TITLE
Update from devel to Nim v1.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,27 @@ cache:
 
 matrix:
   include:
-    # Weave only works with Nim devel
-    # Build and test using both gcc and clang
-    # Build and test on both x86-64 and ARM64
+    - os: linux
+      arch: amd64
+      env:
+        - ARCH=amd64
+        - CHANNEL=stable
+      compiler: gcc
+
+    - os: linux
+      arch: arm64
+      env:
+        - ARCH=arm64
+        - CHANNEL=stable
+      compiler: gcc
+
+    - os: linux
+      arch: amd64
+      env:
+        - ARCH=amd64
+        - CHANNEL=stable
+      compiler: clang
+
     - os: linux
       arch: amd64
       env:
@@ -33,6 +51,13 @@ matrix:
       compiler: clang
 
     # On OSX we only test against clang (gcc is mapped to clang by default)
+    - os: osx
+      arch: amd64
+      env:
+        - ARCH=amd64
+        - CHANNEL=stable
+      compiler: clang
+
     - os: osx
       arch: amd64
       env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,12 @@ strategy:
     #   PLATFORM: x86
     #   CHANNEL: devel
     #   TEST_LANG: c
+    Windows_stable_64bit:
+      VM: 'windows-latest'
+      UCPU: amd64
+      PLATFORM: x64
+      CHANNEL: stable
+      TEST_LANG: c
     Windows_devel_64bit:
       VM: 'windows-latest'
       UCPU: amd64
@@ -24,6 +30,12 @@ strategy:
     #   PLATFORM: x64
     #   CHANNEL: devel
     #   TEST_LANG: cpp
+    Linux_stable_64bit:
+      VM: 'ubuntu-16.04'
+      UCPU: amd64
+      PLATFORM: x64
+      CHANNEL: stable
+      TEST_LANG: c
     Linux_devel_64bit:
       VM: 'ubuntu-16.04'
       UCPU: amd64
@@ -44,7 +56,12 @@ strategy:
     #   UCPU: i686
     #   CHANNEL: devel
     #   TEST_LANG: c
-
+    MacOS_stable_64bit:
+      VM: 'macOS-10.14'
+      UCPU: amd64
+      PLATFORM: x64
+      CHANNEL: stable
+      TEST_LANG: c
     MacOS_devel_64bit:
       VM: 'macOS-10.14'
       UCPU: amd64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,65 +7,54 @@ strategy:
 
     # Windows_devel_32bit:
     #   VM: 'windows-latest'
-    #   ARCH: x86
     #   UCPU: i686
-    #   PLATFORM: x86
     #   CHANNEL: devel
     #   TEST_LANG: c
     Windows_stable_64bit:
       VM: 'windows-latest'
       UCPU: amd64
-      PLATFORM: x64
       CHANNEL: stable
       TEST_LANG: c
     Windows_devel_64bit:
       VM: 'windows-latest'
       UCPU: amd64
-      PLATFORM: x64
       CHANNEL: devel
       TEST_LANG: c
     # Windows_cpp_devel_64bit:
     #   VM: 'windows-latest'
     #   UCPU: amd64
-    #   PLATFORM: x64
     #   CHANNEL: devel
     #   TEST_LANG: cpp
     Linux_stable_64bit:
       VM: 'ubuntu-16.04'
       UCPU: amd64
-      PLATFORM: x64
       CHANNEL: stable
       TEST_LANG: c
     Linux_devel_64bit:
       VM: 'ubuntu-16.04'
       UCPU: amd64
-      PLATFORM: x64
       CHANNEL: devel
       TEST_LANG: c
     # Linux_cpp_devel_64bit:
     #   VM: 'ubuntu-16.04'
     #   UCPU: amd64
-    #   PLATFORM: x64
     #   CHANNEL: devel
-    #   WEAVE_TEST_LANG: cpp
+    #   TEST_LANG: cpp
 
     # Linux_devel_32bit:
     #   VM: 'ubuntu-16.04'
     #   ARCH: x86
-    #   PLATFORM: x86
     #   UCPU: i686
     #   CHANNEL: devel
     #   TEST_LANG: c
     MacOS_stable_64bit:
       VM: 'macOS-10.14'
       UCPU: amd64
-      PLATFORM: x64
       CHANNEL: stable
       TEST_LANG: c
     MacOS_devel_64bit:
       VM: 'macOS-10.14'
       UCPU: amd64
-      PLATFORM: x64
       CHANNEL: devel
       TEST_LANG: c
 pool:
@@ -75,13 +64,13 @@ steps:
   - task: CacheBeta@1
     displayName: 'cache Nim binaries'
     inputs:
-      key: NimBinaries | $(Agent.OS) | $(CHANNEL) | $(PLATFORM)
+      key: NimBinaries | $(Agent.OS) | $(CHANNEL) | $(UCPU)
       path: NimBinaries
 
   - task: CacheBeta@1
     displayName: 'cache MinGW-w64'
     inputs:
-      key: mingwCache | 8_1_0 | $(PLATFORM)
+      key: mingwCache | 8_1_0 | $(UCPU)
       path: mingwCache
     condition: eq(variables['Agent.OS'], 'Windows_NT')
 
@@ -93,7 +82,7 @@ steps:
       echo "PATH=${PATH}"
       set -e
       echo "Installing MinGW-w64"
-      if [[ $PLATFORM == "x86" ]]; then
+      if [[ $UCPU == "i686" ]]; then
         MINGW_FILE="i686-8.1.0-release-posix-dwarf-rt_v6-rev0.7z"
         MINGW_URL="https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/8.1.0/threads-posix/dwarf/${MINGW_FILE}"
         MINGW_DIR="mingw32"
@@ -112,8 +101,18 @@ steps:
       mkdir -p /c/custom
       mv "$MINGW_DIR" /c/custom/
       popd
-      echo "##vso[task.prependpath]/c/custom/${MINGW_DIR}/bin"
+
+      # Workaround https://developercommunity.visualstudio.com/content/problem/891929/windows-2019-cygheap-base-mismatch-detected-git-ba.html
+      echo "##vso[task.prependpath]/usr/bin"
+      echo "##vso[task.prependpath]/mingw64/bin"
+      echo "##vso[task.setvariable variable=MINGW_DIR;]$MINGW_DIR"
+
     displayName: 'Install dependencies (Windows)'
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
+  - powershell: |
+      # export custom mingw PATH to other tasks
+      echo "##vso[task.prependpath]c:\custom\$(MINGW_DIR)\bin"
+    displayName: 'Mingw PATH (Windows)'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
 
   - bash: |
@@ -138,7 +137,7 @@ steps:
   - bash: |
       echo "PATH=${PATH}"
       gcc -v
-      echo "UCPU=${UCPU}"
+      export ucpu=${UCPU}
 
       if [ "${CHANNEL}" = stable ]; then
         BRANCH="v$(curl https://nim-lang.org/channels/stable)"
@@ -168,10 +167,18 @@ steps:
           ./koch tools
         fi
       fi
-      popd # exit nim-CHANNEL
+      popd # exit nim-${CHANNEL}
       popd # exit NimBinaries
-      echo "##vso[task.prependpath]$PWD/NimBinaries/nim-${CHANNEL}/bin"
     displayName: 'Building Nim'
+
+  - powershell: |
+      echo "##vso[task.prependpath]$pwd\NimBinaries\nim-$(CHANNEL)\bin"
+    displayName: 'Set env variable (Windows)'
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
+  - bash: |
+      echo "##vso[task.prependpath]$PWD/NimBinaries/nim-${CHANNEL}/bin"
+    displayName: 'Set env variable (Posix)'
+    condition: ne(variables['Agent.OS'], 'Windows_NT')
 
   - bash: |
       echo "PATH=${PATH}"

--- a/weave.nimble
+++ b/weave.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.0"
+version       = "0.4.0"
 author        = "Mamy André-Ratsimbazafy"
 description   = "a state-of-the-art ùultithreading runtime"
 license       = "MIT or Apache License 2.0"
@@ -8,7 +8,7 @@ license       = "MIT or Apache License 2.0"
 # Dependencies
 
 # requires Nim post abea80376a113fb218c22b6474727c279e694cd3
-requires "nim >= 1.1.1", "synthesis"
+requires "nim >= 1.2.0", "synthesis"
 
 proc test(flags, path: string) =
   if not dirExists "build":

--- a/weave/victims.nim
+++ b/weave/victims.nim
@@ -203,7 +203,7 @@ proc evalSplit(task: Task, req: StealRequest, workSharing: bool): int {.inline.}
       if workSharing:
         # The real splitting will be done by the child worker
         # We need to send it enough work for its own children and all the steal requests pending
-        ascertain: req.thiefID in {myWorker().left, myWorker().right}
+        # ascertain: req.thiefID in {myWorker().left, myWorker().right} # TODO: triggers https://github.com/mratsim/weave/issues/106
         var left, right = 0'i32
         if myWorker().leftIsWaiting:
           left = approxNumThievesProxy(myWorker().left)

--- a/weave/victims.nim
+++ b/weave/victims.nim
@@ -203,7 +203,7 @@ proc evalSplit(task: Task, req: StealRequest, workSharing: bool): int {.inline.}
       if workSharing:
         # The real splitting will be done by the child worker
         # We need to send it enough work for its own children and all the steal requests pending
-        # ascertain: req.thiefID in {myWorker().left, myWorker().right} # TODO: triggers https://github.com/mratsim/weave/issues/106
+        ascertain: req.thiefID == myWorker().left or req.thiefID == myWorker().right
         var left, right = 0'i32
         if myWorker().leftIsWaiting:
           left = approxNumThievesProxy(myWorker().left)


### PR DESCRIPTION
The latest Nim stable v1.2.0 integrates critical requirement for Weave:
- The `{.align.}` pragma https://github.com/nim-lang/Nim/pull/12643, https://github.com/nim-lang/Nim/pull/12666
- Enums as Atomic types https://github.com/nim-lang/Nim/issues/12812

This means that Weave can now target a stable release.

A workaround to reenable C++ compilation (by disabling Pledges) will be added in a separate PR (bug: https://github.com/nim-lang/Nim/issues/13062)