### PR TITLE
Remove parent task tracking

### DIFF
--- a/weave/contexts.nim
+++ b/weave/contexts.nim
@@ -45,8 +45,8 @@ export timers
 # Aliases
 # ----------------------------------------------------------------------------------
 
-template isRootTask*(task: Task): bool =
-  task.parent.isNil
+# template isRootTask*(task: Task): bool =
+#   task.parent.isNil
 
 template myTodoBoxes*: Persistack[WV_MaxConcurrentStealPerWorker, ChannelSpscSinglePtr[Task]] =
   globalCtx.com.tasks[localCtx.worker.ID]
@@ -107,7 +107,6 @@ proc newTaskFromCache*(): Task =
   # Zeroing is expensive, it's 96 bytes
 
   # result.fn = nil # Always overwritten
-  # result.parent = nil # Always overwritten
   # result.scopedBarrier = nil # Always overwritten
   result.prev = nil
   result.next = nil

--- a/weave/datatypes/prell_deques.nim
+++ b/weave/datatypes/prell_deques.nim
@@ -14,8 +14,6 @@ type
     task is ptr
     task.prev is T
     task.next is T
-    # A task has a parent field
-    task.parent is T
     # task has a "fn" field with the proc to run
     task.fn is proc (param: pointer) {.nimcall.}
 
@@ -134,26 +132,6 @@ func addListFirst*[T](dq: var PrellDeque[T], head: sink T) =
     ascertain: cast[ByteAddress](tail.fn) != 0xFACADE
 
   dq.addListFirst(head, tail, count)
-
-# Task-specific routines
-# ---------------------------------------------------------------
-
-func popFirstIfChild*[T](dq: var PrellDeque[T], parentTask: T): T {.inline.} =
-  preCondition: not parentTask.isNil
-
-  if dq.isEmpty():
-    return nil
-
-  result = dq.head
-  if result.parent != parentTask:
-    # Not a child, don't pop it
-    return nil
-
-  dq.head = dq.head.next
-  dq.head.prev = nil
-  result.next = nil
-
-  dq.pendingTasks -= 1
 
 # Work-stealing routines
 # ---------------------------------------------------------------

--- a/weave/datatypes/sync_types.nim
+++ b/weave/datatypes/sync_types.nim
@@ -30,15 +30,14 @@ type
     # We save memory by using int32 instead of int on select properties
     # order field by size to optimize zero initialization (bottleneck on recursive algorithm)
     fn*: proc (param: pointer) {.nimcall, gcsafe.}
-    parent*: Task
     prev*: Task
     next*: Task
-    # 32 bytes
+    # 24 bytes
     start*: int
     cur*: int
     stop*: int
     stride*: int
-    # 64 bytes
+    # 56 bytes
     scopedBarrier*: ptr ScopedBarrier
     futures*: pointer    # LinkedList of futures required by the current task
     futureSize*: uint8   # Size of the future result type if relevant
@@ -47,7 +46,7 @@ type
     isInitialIter*: bool # Awaitable for-loops return true for the initial iter
     when FirstVictim == LastVictim:
       victim*: WorkerID
-    # 84 bytes (or 88 with FirstVictim = LastVictim)
+    # 76 bytes (or 84 with FirstVictim = LastVictim)
     # User data - including the FlowVar channel to send back result.
     # It is very likely that User data contains a pointer (the Flowvar channel)
     # We align to avoid torn reads/extra bookkeeping.

--- a/weave/parallel_for.nim
+++ b/weave/parallel_for.nim
@@ -218,7 +218,7 @@ macro parallelForImpl(loopParams: untyped, stride: int, body: untyped): untyped 
     result.add quote do:
       proc `parForTask`(param: pointer) {.nimcall, gcsafe.} =
         let this = myTask()
-        assert not isRootTask(this)
+        # assert not isRootTask(this)
 
         when bool(`withArgs`):
           let `env` = cast[ptr `CapturedTy`](param)
@@ -230,7 +230,7 @@ macro parallelForImpl(loopParams: untyped, stride: int, body: untyped): untyped 
     result.add quote do:
       proc `parForTask`(param: pointer) {.nimcall, gcsafe.} =
         let this = myTask()
-        assert not isRootTask(this)
+        # assert not isRootTask(this)
 
         let lastLoopIter = cast[ptr FlowVar[bool]](param)
         when bool(`withArgs`):

--- a/weave/parallel_for_staged.nim
+++ b/weave/parallel_for_staged.nim
@@ -176,7 +176,7 @@ macro parallelForStagedImpl*(loopParams: untyped, stride: int, body: untyped): u
     result.add quote do:
       proc `parStagedTask`(param: pointer) {.nimcall, gcsafe.} =
         let this = myTask()
-        assert not isRootTask(this)
+        # assert not isRootTask(this)
 
         when bool(`withArgs`):
           let `env` = cast[ptr `CapturedTy`](param)
@@ -188,7 +188,7 @@ macro parallelForStagedImpl*(loopParams: untyped, stride: int, body: untyped): u
     result.add quote do:
       proc `parStagedTask`(param: pointer) {.nimcall, gcsafe.} =
         let this = myTask()
-        assert not isRootTask(this)
+        # assert not isRootTask(this)
 
         let lastLoopIter = cast[ptr FlowVar[bool]](param)
         when bool(`withArgs`):

--- a/weave/parallel_macros.nim
+++ b/weave/parallel_macros.nim
@@ -298,7 +298,6 @@ proc addLoopTask*(
           timer_start(timer_enq_deq_task)
         block enq_deq_task:
           let `task` = newTaskFromCache()
-          `task`.parent = myTask()
           `task`.fn = `asyncFn`
           registerDescendant(mySyncScope())
           `task`.scopedBarrier = mySyncScope()
@@ -329,7 +328,6 @@ proc addLoopTask*(
           timer_start(timer_enq_deq_task)
         block enq_deq_task:
           let `task` = newTaskFromCache()
-          `task`.parent = myTask()
           `task`.fn = `asyncFn`
           registerDescendant(mySyncScope())
           `task`.scopedBarrier = mySyncScope()

--- a/weave/parallel_reduce.nim
+++ b/weave/parallel_reduce.nim
@@ -207,7 +207,7 @@ macro parallelReduceImpl*(loopParams: untyped, stride: int, body: untyped): unty
   result.add quote do:
     proc `parReduceTask`(param: pointer) {.nimcall, gcsafe.} =
       let this = myTask()
-      assert not isRootTask(this)
+      # assert not isRootTask(this)
 
       let `fut` = cast[ptr `FutTy`](param)
       when bool(`withArgs`):

--- a/weave/parallel_tasks.nim
+++ b/weave/parallel_tasks.nim
@@ -102,7 +102,7 @@ proc spawnImpl(pledges: NimNode, funcCall: NimNode): NimNode =
     # Create the async call
     result.add quote do:
       proc `async_fn`(param: pointer) {.nimcall.} =
-        preCondition: not isRootTask(myTask())
+        # preCondition: not isRootTask(myTask())
 
         when bool(`withArgs`):
           let `data` = cast[ptr `argsTy`](param) # TODO - restrict
@@ -114,7 +114,6 @@ proc spawnImpl(pledges: NimNode, funcCall: NimNode): NimNode =
         timer_start(timer_enq_deq_task)
       block enq_deq_task:
         let `task` = newTaskFromCache()
-        `task`.parent = myTask()
         `task`.fn = `async_fn`
         registerDescendant(mySyncScope())
         `task`.scopedBarrier = mySyncScope()
@@ -149,7 +148,7 @@ proc spawnImpl(pledges: NimNode, funcCall: NimNode): NimNode =
 
     result.add quote do:
       proc `async_fn`(param: pointer) {.nimcall.} =
-        preCondition: not isRootTask(myTask())
+        # preCondition: not isRootTask(myTask())
 
         let `data` = cast[ptr `futArgsTy`](param) # TODO - restrict
         let res = `fnCall`
@@ -163,7 +162,6 @@ proc spawnImpl(pledges: NimNode, funcCall: NimNode): NimNode =
         timer_start(timer_enq_deq_task)
       block enq_deq_task:
         let `task` = newTaskFromCache()
-        `task`.parent = myTask()
         `task`.fn = `async_fn`
         registerDescendant(mySyncScope())
         `task`.scopedBarrier = mySyncScope()

--- a/weave/runtime.nim
+++ b/weave/runtime.nim
@@ -71,7 +71,6 @@ proc init*(_: type Weave) =
 
   # Root task
   myWorker().currentTask = newTaskFromCache()
-  myTask().parent = nil
   myTask().fn = cast[type myTask().fn](0xEFFACED)
   myTask().scopedBarrier = nil
 
@@ -144,7 +143,7 @@ proc globalCleanup() =
   wv_free(globalCtx.com.tasks)
 
   # The root task has no parent
-  ascertain: myTask().isRootTask()
+  # ascertain: myTask().isRootTask()
   delete(myTask())
 
   # TODO takeover the leftover pools

--- a/weave/signals.nim
+++ b/weave/signals.nim
@@ -32,7 +32,6 @@ proc asyncSignal(fn: proc (_: pointer) {.nimcall, gcsafe.}, chan: var ChannelSps
   profile(send_recv_task):
     let dummy = newTaskFromCache()
     dummy.fn = fn
-    dummy.parent = myTask()
     mySyncScope().registerDescendant
     dummy.scopedBarrier = mySyncScope()
     TargetLastVictim:

--- a/weave/state_machines/dispatch_events.nim
+++ b/weave/state_machines/dispatch_events.nim
@@ -13,12 +13,9 @@ import
   ../thieves,
   ./decline_thief, ./handle_thieves
 
-proc nextTask*(childTask: static bool): Task {.inline.} =
+proc nextTask*(): Task {.inline.} =
   profile(enq_deq_task):
-    if childTask:
-      result = myWorker().deque.popFirstIfChild(myTask())
-    else:
-      result = myWorker().deque.popFirst()
+    result = myWorker().deque.popFirst()
 
   when WV_StealEarly > 0:
     if not result.isNil:

--- a/weave/state_machines/event_loop.nim
+++ b/weave/state_machines/event_loop.nim
@@ -70,7 +70,7 @@ behavior(workerEventLoop):
 onEntry(workerEventLoop, WEL_CheckTask):
   # If we have extra tasks, prio is: children, then thieves then us
   # This is done in `nextTask`
-  let task = nextTask(childTask = false)
+  let task = nextTask()
 
 implEvent(workerEventLoop, EV_FoundTask):
   not task.isNil

--- a/weave/state_machines/sync_root.nim
+++ b/weave/state_machines/sync_root.nim
@@ -49,7 +49,7 @@ setPrologue(syncRootFSA):
   Worker: return
   debugTermination:
     log(">>> Worker %2d enters barrier <<<\n", myID())
-  preCondition: myTask().isRootTask()
+  # preCondition: myTask().isRootTask()
 
   debug: log("Worker %2d: syncRoot 1 - task from local deque\n", myID())
   var task: Task
@@ -78,7 +78,7 @@ implEvent(syncRootFSA, SYE_SoleWorker):
 # -------------------------------------------
 
 onEntry(syncRootFSA, SY_CheckTask):
-  task = nextTask(childTask = false)
+  task = nextTask()
 
 behavior(syncRootFSA):
   ini: SY_CheckTask

--- a/weave/state_machines/sync_scope.nim
+++ b/weave/state_machines/sync_scope.nim
@@ -80,7 +80,7 @@ implEvent(syncScopeFSA, SBE_HasTask):
   not task.isNil
 
 onEntry(syncScopeFSA, SB_CheckTask):
-  task = nextTask(childTask = false)
+  task = nextTask()
 
 behavior(syncScopeFSA):
   ini: SB_CheckTask


### PR DESCRIPTION
Flawed experiments at removing parent task tracking.

Flawed Rational: the `interrupt` functionality of the state machine should have helped shortcutting as ASAP

This slow down the library by about 4.5x Ugh.

![image](https://user-images.githubusercontent.com/22738317/81486906-9999eb00-9258-11ea-8c59-409081799658.png)
