### PR TITLE
Change mpsc counting

### DIFF
--- a/weave/contexts.nim
+++ b/weave/contexts.nim
@@ -61,10 +61,10 @@ template myTodoBoxes*: Persistack[WV_MaxConcurrentStealPerWorker, ChannelSpscSin
 template managerJobQueue*: ChannelMpscUnboundedBatch[Job] =
   globalCtx.manager.jobsIncoming[]
 
-template myThieves*: ChannelMpscUnboundedBatch[StealRequest] =
+template myThieves*: ChannelMpscUnboundedBatch[StealRequest, keepCount = true] =
   globalCtx.com.thefts[workerContext.worker.ID]
 
-template getThievesOf*(worker: WorkerID): ChannelMpscUnboundedBatch[StealRequest] =
+template getThievesOf*(worker: WorkerID): ChannelMpscUnboundedBatch[StealRequest, keepCount = true] =
   globalCtx.com.thefts[worker]
 
 template myMemPool*: TLPoolAllocator =

--- a/weave/contexts.nim
+++ b/weave/contexts.nim
@@ -58,7 +58,7 @@ template isRootTask*(task: Task): bool =
 template myTodoBoxes*: Persistack[WV_MaxConcurrentStealPerWorker, ChannelSpscSinglePtr[Task]] =
   globalCtx.com.tasksStolen[workerContext.worker.ID]
 
-template managerJobQueue*: ChannelMpscUnboundedBatch[Job] =
+template managerJobQueue*: ChannelMpscUnboundedBatch[Job, keepCount = false] =
   globalCtx.manager.jobsIncoming[]
 
 template myThieves*: ChannelMpscUnboundedBatch[StealRequest, keepCount = true] =

--- a/weave/cross_thread_com/channels_mpsc_unbounded_batch.nim
+++ b/weave/cross_thread_com/channels_mpsc_unbounded_batch.nim
@@ -141,7 +141,7 @@ proc tryRecv*[T, keepCount](chan: var ChannelMpscUnboundedBatch[T, keepCount], d
 
       when keepCount:
         let oldCount {.used.} = chan.count.fetchSub(1, moRelaxed)
-        ascertain: oldCount >= 1 # The producers may overestimate the count
+        postCondition: oldCount >= 1 # The producers may overestimate the count
       return true
   # End fast-path
 
@@ -160,7 +160,7 @@ proc tryRecv*[T, keepCount](chan: var ChannelMpscUnboundedBatch[T, keepCount], d
 
     when keepCount:
       let oldCount {.used.} = chan.count.fetchSub(1, moRelaxed)
-      ascertain: oldCount >= 1 # The producers may overestimate the count
+      postCondition: oldCount >= 1 # The producers may overestimate the count
     return true
 
   # We lost but now we know that there is an extra node coming very soon
@@ -182,7 +182,7 @@ proc tryRecv*[T, keepCount](chan: var ChannelMpscUnboundedBatch[T, keepCount], d
 
   when keepCount:
     let oldCount {.used.} = chan.count.fetchSub(1, moRelaxed)
-    ascertain: oldCount >= 1 # The producers may overestimate the count
+    postCondition: oldCount >= 1 # The producers may overestimate the count
   return true
 
   # # Alternative implementation

--- a/weave/cross_thread_com/pledges.nim
+++ b/weave/cross_thread_com/pledges.nim
@@ -171,7 +171,7 @@ type
     # The MPSC Channel is intrusive to the PledgeImpl.
     # The end fields in the channel should be the consumer
     # to avoid cache-line conflicts with producer threads.
-    chan: ChannelMpscUnboundedBatch[TaskNode]
+    chan: ChannelMpscUnboundedBatch[TaskNode, keepCount = false]
     deferredIn: Atomic[int32]
     deferredOut: Atomic[int32]
     fulfilled: Atomic[bool]
@@ -535,8 +535,8 @@ debugSizeAsserts:
   doAssert sizeof(default(TaskNode)[]) == expectedSize,
     "TaskNode size was " & $sizeof(default(TaskNode)[])
 
-  doAssert sizeof(ChannelMpscUnboundedBatch[TaskNode]) == 128,
-    "MPSC channel size was " & $sizeof(ChannelMpscUnboundedBatch[TaskNode])
+  doAssert sizeof(ChannelMpscUnboundedBatch[TaskNode, false]) == 128,
+    "MPSC channel size was " & $sizeof(ChannelMpscUnboundedBatch[TaskNode, false])
 
   doAssert sizeof(PledgeImpl) == 192,
     "PledgeImpl size was " & $sizeof(PledgeImpl)

--- a/weave/datatypes/context_global.nim
+++ b/weave/datatypes/context_global.nim
@@ -37,8 +37,8 @@ type
     #   per channel and a known max number of workers
 
     # Theft channels are bounded to "NumWorkers * WV_MaxConcurrentStealPerWorker"
-    thefts*: ptr UncheckedArray[ChannelMpscUnboundedBatch[StealRequest]]
     tasksStolen*: ptr UncheckedArray[Persistack[WV_MaxConcurrentStealPerWorker, ChannelSpscSinglePtr[Task]]]
+    thefts*: ptr UncheckedArray[ChannelMpscUnboundedBatch[StealRequest, keepCount = true]]
     when static(WV_Backoff):
       parking*: ptr UncheckedArray[EventNotifier]
 

--- a/weave/datatypes/context_global.nim
+++ b/weave/datatypes/context_global.nim
@@ -63,7 +63,7 @@ type
     #
     # It may become a thread dedicated to supervision, synchronization
     # and job handling.
-    jobsIncoming*: ptr ChannelMpscUnboundedBatch[Job]
+    jobsIncoming*: ptr ChannelMpscUnboundedBatch[Job, keepCount = false]
     when static(WV_Backoff):
       jobNotifier*: ptr EventNotifier
         ## When Weave works as a dedicated execution engine

--- a/weave/runtime.nim
+++ b/weave/runtime.nim
@@ -45,8 +45,8 @@ proc init*(_: type Weave) =
   ## Allocation of the global context.
   globalCtx.mempools = wv_alloc(TLPoolAllocator, workforce())
   globalCtx.threadpool = wv_alloc(Thread[WorkerID], workforce())
-  globalCtx.com.thefts = wv_alloc(ChannelMpscUnboundedBatch[StealRequest], workforce())
   globalCtx.com.tasksStolen = wv_alloc(Persistack[WV_MaxConcurrentStealPerWorker, ChannelSpscSinglePtr[Task]], workforce())
+  globalCtx.com.thefts = wv_alloc(ChannelMpscUnboundedBatch[StealRequest, true], workforce())
   Backoff:
     globalCtx.com.parking = wv_alloc(EventNotifier, workforce())
   globalCtx.barrier.init(workforce())

--- a/weave/runtime.nim
+++ b/weave/runtime.nim
@@ -84,7 +84,7 @@ proc init*(_: type Weave) =
 
   # Manager
   manager.jobNotifier = globalCtx.com.parking[0].addr
-  manager.jobsIncoming = wv_alloc(ChannelMpscUnboundedBatch[Job])
+  manager.jobsIncoming = wv_alloc(ChannelMpscUnboundedBatch[Job, false])
   manager.jobsIncoming[].initialize()
 
   # Wait for the child threads


### PR DESCRIPTION
This does 2 things:

- MPSC count is now optional, implementing the last part of #93
- MPSC count sanity checks does not load(moRelaxed) but directly check the old count returned by fetchAdd

This should:
- fix https://github.com/mratsim/weave/issues/49 
- fix https://github.com/mratsim/weave/issues/85
- close #93