### PR TITLE
Load balance child wakeup

### DIFF
--- a/weave/datatypes/prell_deques.nim
+++ b/weave/datatypes/prell_deques.nim
@@ -109,7 +109,7 @@ proc flush*[T: StealableTask](dq: var PrellDeque[T]): T {.inline.} =
 # Batch routines
 # ---------------------------------------------------------------
 
-func addListFirst[T](dq: var PrellDeque[T], head, tail: sink T, len: int32) {.inline.} =
+func addListFirst*[T](dq: var PrellDeque[T], head, tail: sink T, len: int32) {.inline.} =
   # Add a list of tasks [head ... tail] of length len to the front of the deque
   preCondition: not head.isNil and not tail.isNil
   preCondition: len > 0

--- a/weave/executor.nim
+++ b/weave/executor.nim
@@ -113,7 +113,8 @@ proc processAllandTryPark*(_: typedesc[Weave]) =
 
 proc wakeup(_: typedesc[Weave]) =
   ## Wakeup the runtime manager if asleep
-  manager.jobNotifier[].notify()
+  Backoff:
+    manager.jobNotifier[].notify()
 
 proc runForever*(_: typedesc[Weave]) =
   ## Start a never-ending event loop on the current thread

--- a/weave/parallel_jobs.nim
+++ b/weave/parallel_jobs.nim
@@ -17,7 +17,7 @@ import
   macros, typetraits, atomics, os,
   # Internal
   ./memory/[allocs, memory_pools],
-  ./scheduler, ./contexts,
+  ./scheduler, ./contexts, ./config,
   ./datatypes/[flowvars, sync_types],
   ./instrumentation/contracts,
   ./cross_thread_com/[pledges, channels_mpsc_unbounded_batch, event_notifiers],
@@ -28,7 +28,8 @@ proc newJob(): Job {.inline.} =
   jobProviderContext.mempool[].borrow(deref(Job))
 
 proc notifyJob() {.inline.} =
-  manager.jobNotifier[].notify()
+  Backoff:
+    manager.jobNotifier[].notify()
 
 proc submitImpl(pledges: NimNode, funcCall: NimNode): NimNode =
   # We take typed argument so that overloading resolution

--- a/weave/runtime.nim
+++ b/weave/runtime.nim
@@ -83,7 +83,8 @@ proc init*(_: type Weave) =
   setupWorker()
 
   # Manager
-  manager.jobNotifier = globalCtx.com.parking[0].addr
+  Backoff:
+    manager.jobNotifier = globalCtx.com.parking[0].addr
   manager.jobsIncoming = wv_alloc(ChannelMpscUnboundedBatch[Job, false])
   manager.jobsIncoming[].initialize()
 


### PR DESCRIPTION
This PR does:

- ensure that Weave compiles without Backoff after #136 
- A parent will give half its tasks when waking up its children, whatever they requested.
  This solves #90 by diffusing tasks much faster to the leaves.
  Impact is 10% overhead reduction on fibonacci: 
![image](https://user-images.githubusercontent.com/22738317/82128812-3d861800-97be-11ea-8875-b58fc6e6f32c.png) (~350 ms instead of ~385 ms)
- This should significantly help when Weave is used as a background service as well.
