### PR TITLE
Mpsc channel v3

### DIFF
--- a/weave/cross_thread_com/channels_mpsc_unbounded_batch.nim
+++ b/weave/cross_thread_com/channels_mpsc_unbounded_batch.nim
@@ -119,7 +119,7 @@ proc trySendImpl[T, keepCount](chan: var ChannelMpscUnboundedBatch[T, keepCount]
 
   return true
 
-proc trySend[T, keepCount](chan: var ChannelMpscUnboundedBatch[T, keepCount], src: sink T): bool =
+proc trySend*[T, keepCount](chan: var ChannelMpscUnboundedBatch[T, keepCount], src: sink T): bool =
   ## Send an item to the back of the channel
   ## As the channel has unbounded capacity, this should never fail
   trySendImpl(chan, src, dummy = false)

--- a/weave/cross_thread_com/channels_mpsc_unbounded_batch.nim
+++ b/weave/cross_thread_com/channels_mpsc_unbounded_batch.nim
@@ -56,7 +56,7 @@ type
     # Accessed by all
     count: Atomic[int]
     # Channel invariant, never really empty so that producer can "exchange"
-    dummy: typeof(default(T)[])
+    dummy{.align: MpscPadding.}: typeof(default(T)[])
     # Consumer only
     front: T
     # back and front order is chosen so that the data structure can be

--- a/weave/datatypes/prell_deques.nim
+++ b/weave/datatypes/prell_deques.nim
@@ -113,7 +113,8 @@ func addListFirst*[T](dq: var PrellDeque[T], head, tail: sink T, len: int32) {.i
   # Add a list of tasks [head ... tail] of length len to the front of the deque
   preCondition: not head.isNil and not tail.isNil
   preCondition: len > 0
-  preCondition: tail.next.isNil
+
+  # preCondition: tail.next.isNil - not true if coming from another intrusive data structure
 
   # Link tail with deque head
   tail.next = dq.head

--- a/weave/memory/memory_pools.nim
+++ b/weave/memory/memory_pools.nim
@@ -66,7 +66,7 @@ template debugMem*(body: untyped) =
 
 const SizeofMetadata: int = (block:
     var size: int
-    size += 320                               # ChannelMpscUnboundedBatch
+    size += 384                               # ChannelMpscUnboundedBatch
     size += sizeof(pointer)                   # localFree
     size += sizeof(pointer)                   # free
     size += sizeof(int32)                     # used
@@ -636,7 +636,7 @@ proc takeover*(pool: var TLPoolAllocator, target: sink TLPoolAllocator) =
 #       the size here will likely be wrong
 
 debugSizeAsserts:
-  doAssert sizeof(ChannelMpscUnboundedBatch[ptr MemBlock, keepCount = true]) == 320,
+  doAssert sizeof(ChannelMpscUnboundedBatch[ptr MemBlock, keepCount = true]) == 384,
     "MPSC channel size was " & $sizeof(ChannelMpscUnboundedBatch[ptr MemBlock, keepCount = true])
 
   doAssert sizeof(Arena) == WV_MemArenaSize,


### PR DESCRIPTION
A rewrite of the core MPSC channel with the following benefits:
- No CompareExchange at all for the consumer. CompareExchange is the costliest atomic especially on weak memory model
- No spinlock / cpuRelax. While they don't yield the processor, busy waiting is bad style.

This is the revival of the v1 channels that didn't support batching, but with a State Machine twist:
https://github.com/mratsim/weave/blob/b796d1a0efb15cad68e2b06ddaa305b08cf5f722/weave/channels/channels_mpsc_unbounded.nim

Trying to add batching support to the `tryRecv` proc was incredibly hard and ultimately failed due to the moving dummy and the non-trivial control flow, hence the v2 design with a fixed dummy node in front.

Pure queue benchmarks are inconclusive, the v3 seems to be slightly better for single task dequeue but is slower for batch dequeue :/.

![image](https://user-images.githubusercontent.com/22738317/82161823-67b00680-98a0-11ea-87c6-fbcf076ba54c.png)

Impact on actual workload to be measured
