### PR TITLE
install deps for tests

### DIFF
--- a/weave.nimble
+++ b/weave.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.4.9"
+version       = "0.4.10"
 author        = "Mamy André-Ratsimbazafy"
 description   = "a state-of-the-art multithreading runtime"
 license       = "MIT or Apache License 2.0"
@@ -98,6 +98,7 @@ task test, "Run Weave tests":
         test "-d:danger", "benchmarks/matmul_gemm_blas/test_gemm_output.nim"
 
 task test_gc_arc, "Run Weave tests with --gc:arc":
+  exec "nimble install cligen"
   test "--gc:arc", "weave/cross_thread_com/channels_spsc_single.nim"
   test "--gc:arc", "weave/cross_thread_com/channels_spsc_single_ptr.nim"
   test "--gc:arc", "weave/cross_thread_com/channels_mpsc_unbounded_batch.nim"


### PR DESCRIPTION
The Nim repo executes `nimble test_gc_arc` to make sure weave works on devel. But weave needs cligen dep to run `weave/benchmarks/matrix_transposition/weave_transposes.nim`. It got error:

```
/home/runner/work/Nim/Nim/pkgstemp/weave/benchmarks/matrix_transposition/
weave_transposes.nim(16, 3) Error: cannot open file: cligen
```

ref https://github.com/nim-lang/Nim/pull/19762